### PR TITLE
QOL Fixes

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -94,13 +94,14 @@ const hooks = {};
             "prefix": hookName,
             "body": [
               `/**`,
-              ` * Implements ${hookName}.`,
+              ` * Implements ${hookName}().`,
               ` */`,
               `function ${usage} {`,
               `  $0`,
               `}`
             ],
             "description": [
+              `${hookName}`,
               `Drupal ${coreVersion}+`,
               ``
             ],
@@ -140,6 +141,8 @@ const hooks = {};
               const type = note.match(/^\w*/g)[0];
 
               if (type == 'deprecated') {
+
+                hooks[hookName].description[0] = `${hookName} (Deprecated)`;
                 note = note.trim().split(/\n/g);
                 hooks[hookName].description.push("", ...note);
                 hooks[hookName].body.push('//deprecated');

--- a/snippets/hooks.json
+++ b/snippets/hooks.json
@@ -3,13 +3,14 @@
 		"prefix": "hook_cron",
 		"body": [
 			"/**",
-			" * Implements hook_cron.",
+			" * Implements hook_cron().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_cron() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_cron",
 			"Drupal 8+",
 			"",
 			"Perform periodic actions.",
@@ -32,13 +33,14 @@
 		"prefix": "hook_data_type_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_data_type_info_alter.",
+			" * Implements hook_data_type_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_data_type_info_alter(&\\$data_types) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_data_type_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter available data types for typed data wrappers."
@@ -49,13 +51,14 @@
 		"prefix": "hook_queue_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_queue_info_alter.",
+			" * Implements hook_queue_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_queue_info_alter(&\\$queues) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_queue_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter cron queue information before cron runs.",
@@ -68,13 +71,14 @@
 		"prefix": "hook_mail_alter",
 		"body": [
 			"/**",
-			" * Implements hook_mail_alter.",
+			" * Implements hook_mail_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_mail_alter(&\\$message) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_mail_alter",
 			"Drupal 8+",
 			"",
 			"Alter an email message created with MailManagerInterface->mail().",
@@ -93,13 +97,14 @@
 		"prefix": "hook_mail",
 		"body": [
 			"/**",
-			" * Implements hook_mail.",
+			" * Implements hook_mail().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_mail(\\$key, &\\$message, \\$params) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_mail",
 			"Drupal 8+",
 			"",
 			"Prepares a message based on parameters;",
@@ -113,13 +118,14 @@
 		"prefix": "hook_mail_backend_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_mail_backend_info_alter.",
+			" * Implements hook_mail_backend_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_mail_backend_info_alter(&\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_mail_backend_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the list of mail backend plugin definitions."
@@ -130,13 +136,14 @@
 		"prefix": "hook_countries_alter",
 		"body": [
 			"/**",
-			" * Implements hook_countries_alter.",
+			" * Implements hook_countries_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_countries_alter(&\\$countries) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_countries_alter",
 			"Drupal 8+",
 			"",
 			"Alter the default country list."
@@ -147,13 +154,14 @@
 		"prefix": "hook_display_variant_plugin_alter",
 		"body": [
 			"/**",
-			" * Implements hook_display_variant_plugin_alter.",
+			" * Implements hook_display_variant_plugin_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_display_variant_plugin_alter(array &\\$definitions) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_display_variant_plugin_alter",
 			"Drupal 8+",
 			"",
 			"Alter display variant plugin definitions."
@@ -164,13 +172,14 @@
 		"prefix": "hook_layout_alter",
 		"body": [
 			"/**",
-			" * Implements hook_layout_alter.",
+			" * Implements hook_layout_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_layout_alter(&\\$definitions) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_layout_alter",
 			"Drupal 8+",
 			"",
 			"Allow modules to alter layout plugin definitions."
@@ -181,13 +190,14 @@
 		"prefix": "hook_cache_flush",
 		"body": [
 			"/**",
-			" * Implements hook_cache_flush.",
+			" * Implements hook_cache_flush().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_cache_flush() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_cache_flush",
 			"Drupal 8+",
 			"",
 			"Flush all persistent and static caches.",
@@ -208,13 +218,14 @@
 		"prefix": "hook_rebuild",
 		"body": [
 			"/**",
-			" * Implements hook_rebuild.",
+			" * Implements hook_rebuild().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_rebuild() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_rebuild",
 			"Drupal 8+",
 			"",
 			"Rebuild data based upon refreshed caches.",
@@ -232,13 +243,14 @@
 		"prefix": "hook_config_import_steps_alter",
 		"body": [
 			"/**",
-			" * Implements hook_config_import_steps_alter.",
+			" * Implements hook_config_import_steps_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_config_import_steps_alter(&\\$sync_steps, \\Drupal\\Core\\Config\\ConfigImporter \\$config_importer) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_config_import_steps_alter",
 			"Drupal 8+",
 			"",
 			"Alter the configuration synchronization steps."
@@ -249,13 +261,14 @@
 		"prefix": "hook_config_schema_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_config_schema_info_alter.",
+			" * Implements hook_config_schema_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_config_schema_info_alter(&\\$definitions) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_config_schema_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter config typed data definitions.",
@@ -275,13 +288,14 @@
 		"prefix": "hook_validation_constraint_alter",
 		"body": [
 			"/**",
-			" * Implements hook_validation_constraint_alter.",
+			" * Implements hook_validation_constraint_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_validation_constraint_alter(array &\\$definitions) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_validation_constraint_alter",
 			"Drupal 8+",
 			"",
 			"Alter validation constraint plugin definitions."
@@ -292,13 +306,14 @@
 		"prefix": "hook_query_alter",
 		"body": [
 			"/**",
-			" * Implements hook_query_alter.",
+			" * Implements hook_query_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_query_alter(Drupal\\Core\\Database\\Query\\AlterableInterface \\$query) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_query_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations to a structured query.",
@@ -311,13 +326,14 @@
 		"prefix": "hook_query_TAG_alter",
 		"body": [
 			"/**",
-			" * Implements hook_query_TAG_alter.",
+			" * Implements hook_query_TAG_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_query_${2:TAG}_alter(Drupal\\Core\\Database\\Query\\AlterableInterface \\$query) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_query_TAG_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations to a structured query for a given tag.",
@@ -333,13 +349,14 @@
 		"prefix": "hook_schema",
 		"body": [
 			"/**",
-			" * Implements hook_schema.",
+			" * Implements hook_schema().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_schema() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_schema",
 			"Drupal 8+",
 			"",
 			"Define the current version of the database schema.",
@@ -365,13 +382,14 @@
 		"prefix": "hook_entity_access",
 		"body": [
 			"/**",
-			" * Implements hook_entity_access.",
+			" * Implements hook_entity_access().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_access(\\Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$operation, \\Drupal\\Core\\Session\\AccountInterface \\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_access",
 			"Drupal 8+",
 			"",
 			"Control entity operation access.",
@@ -384,13 +402,14 @@
 		"prefix": "hook_ENTITY_TYPE_access",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_access.",
+			" * Implements hook_ENTITY_TYPE_access().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_access(\\Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$operation, \\Drupal\\Core\\Session\\AccountInterface \\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_access",
 			"Drupal 8+",
 			"",
 			"Control entity operation access for a specific entity type.",
@@ -403,13 +422,14 @@
 		"prefix": "hook_entity_create_access",
 		"body": [
 			"/**",
-			" * Implements hook_entity_create_access.",
+			" * Implements hook_entity_create_access().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_create_access(\\Drupal\\Core\\Session\\AccountInterface \\$account, array \\$context, \\$entity_bundle) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_create_access",
 			"Drupal 8+",
 			"",
 			"Control entity create access."
@@ -420,13 +440,14 @@
 		"prefix": "hook_ENTITY_TYPE_create_access",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_create_access.",
+			" * Implements hook_ENTITY_TYPE_create_access().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_create_access(\\Drupal\\Core\\Session\\AccountInterface \\$account, array \\$context, \\$entity_bundle) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_create_access",
 			"Drupal 8+",
 			"",
 			"Control entity create access for a specific entity type."
@@ -437,13 +458,14 @@
 		"prefix": "hook_entity_type_build",
 		"body": [
 			"/**",
-			" * Implements hook_entity_type_build.",
+			" * Implements hook_entity_type_build().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_type_build(array &\\$entity_types) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_type_build",
 			"Drupal 8+",
 			"",
 			"Add to entity type definitions.",
@@ -458,13 +480,14 @@
 		"prefix": "hook_entity_type_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_type_alter.",
+			" * Implements hook_entity_type_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_type_alter(array &\\$entity_types) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_type_alter",
 			"Drupal 8+",
 			"",
 			"Alter the entity type definitions.",
@@ -485,13 +508,14 @@
 		"prefix": "hook_entity_view_mode_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_view_mode_info_alter.",
+			" * Implements hook_entity_view_mode_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_view_mode_info_alter(&\\$view_modes) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_view_mode_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the view modes for entity types."
@@ -502,13 +526,14 @@
 		"prefix": "hook_entity_bundle_info",
 		"body": [
 			"/**",
-			" * Implements hook_entity_bundle_info.",
+			" * Implements hook_entity_bundle_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_bundle_info() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_bundle_info",
 			"Drupal 8+",
 			"",
 			"Describe the bundles for entity types."
@@ -519,13 +544,14 @@
 		"prefix": "hook_entity_bundle_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_bundle_info_alter.",
+			" * Implements hook_entity_bundle_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_bundle_info_alter(&\\$bundles) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_bundle_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the bundles for entity types."
@@ -536,13 +562,14 @@
 		"prefix": "hook_entity_bundle_create",
 		"body": [
 			"/**",
-			" * Implements hook_entity_bundle_create.",
+			" * Implements hook_entity_bundle_create().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_bundle_create(\\$entity_type_id, \\$bundle) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_bundle_create",
 			"Drupal 8+",
 			"",
 			"Act on entity_bundle_create().",
@@ -554,13 +581,14 @@
 		"prefix": "hook_entity_bundle_delete",
 		"body": [
 			"/**",
-			" * Implements hook_entity_bundle_delete.",
+			" * Implements hook_entity_bundle_delete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_bundle_delete(\\$entity_type_id, \\$bundle) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_bundle_delete",
 			"Drupal 8+",
 			"",
 			"Act on entity_bundle_delete().",
@@ -572,13 +600,14 @@
 		"prefix": "hook_entity_create",
 		"body": [
 			"/**",
-			" * Implements hook_entity_create.",
+			" * Implements hook_entity_create().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_create(\\Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_create",
 			"Drupal 8+",
 			"",
 			"Acts when creating a new entity.",
@@ -590,13 +619,14 @@
 		"prefix": "hook_ENTITY_TYPE_create",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_create.",
+			" * Implements hook_ENTITY_TYPE_create().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_create(\\Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_create",
 			"Drupal 8+",
 			"",
 			"Acts when creating a new entity of a specific type.",
@@ -608,13 +638,14 @@
 		"prefix": "hook_entity_revision_create",
 		"body": [
 			"/**",
-			" * Implements hook_entity_revision_create.",
+			" * Implements hook_entity_revision_create().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_revision_create(Drupal\\Core\\Entity\\EntityInterface \\$new_revision, Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$keep_untranslatable_fields) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_revision_create",
 			"Drupal 8+",
 			"",
 			"Respond to entity revision creation."
@@ -625,13 +656,14 @@
 		"prefix": "hook_ENTITY_TYPE_revision_create",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_revision_create.",
+			" * Implements hook_ENTITY_TYPE_revision_create().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_revision_create(Drupal\\Core\\Entity\\EntityInterface \\$new_revision, Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$keep_untranslatable_fields) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_revision_create",
 			"Drupal 8+",
 			"",
 			"Respond to entity revision creation."
@@ -642,13 +674,14 @@
 		"prefix": "hook_entity_preload",
 		"body": [
 			"/**",
-			" * Implements hook_entity_preload.",
+			" * Implements hook_entity_preload().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_preload(array \\$ids, \\$entity_type_id) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_preload",
 			"Drupal 8+",
 			"",
 			"Act on an array of entity IDs before they are loaded.",
@@ -661,13 +694,14 @@
 		"prefix": "hook_entity_load",
 		"body": [
 			"/**",
-			" * Implements hook_entity_load.",
+			" * Implements hook_entity_load().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_load(array \\$entities, \\$entity_type_id) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_load",
 			"Drupal 8+",
 			"",
 			"Act on entities when loaded.",
@@ -682,13 +716,14 @@
 		"prefix": "hook_ENTITY_TYPE_load",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_load.",
+			" * Implements hook_ENTITY_TYPE_load().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_load(\\$entities) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_load",
 			"Drupal 8+",
 			"",
 			"Act on entities of a specific type when loaded."
@@ -699,13 +734,14 @@
 		"prefix": "hook_entity_storage_load",
 		"body": [
 			"/**",
-			" * Implements hook_entity_storage_load.",
+			" * Implements hook_entity_storage_load().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_storage_load(array \\$entities, \\$entity_type) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_storage_load",
 			"Drupal 8+",
 			"",
 			"Act on content entities when loaded from the storage.",
@@ -717,13 +753,14 @@
 		"prefix": "hook_ENTITY_TYPE_storage_load",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_storage_load.",
+			" * Implements hook_ENTITY_TYPE_storage_load().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_storage_load(array \\$entities) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_storage_load",
 			"Drupal 8+",
 			"",
 			"Act on content entities of a given type when loaded from the storage.",
@@ -735,13 +772,14 @@
 		"prefix": "hook_entity_presave",
 		"body": [
 			"/**",
-			" * Implements hook_entity_presave.",
+			" * Implements hook_entity_presave().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_presave(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_presave",
 			"Drupal 8+",
 			"",
 			"Act on an entity before it is created or updated.",
@@ -754,13 +792,14 @@
 		"prefix": "hook_ENTITY_TYPE_presave",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_presave.",
+			" * Implements hook_ENTITY_TYPE_presave().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_presave(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_presave",
 			"Drupal 8+",
 			"",
 			"Act on a specific type of entity before it is created or updated.",
@@ -773,13 +812,14 @@
 		"prefix": "hook_entity_insert",
 		"body": [
 			"/**",
-			" * Implements hook_entity_insert.",
+			" * Implements hook_entity_insert().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_insert(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_insert",
 			"Drupal 8+",
 			"",
 			"Respond to creation of a new entity.",
@@ -792,13 +832,14 @@
 		"prefix": "hook_ENTITY_TYPE_insert",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_insert.",
+			" * Implements hook_ENTITY_TYPE_insert().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_insert(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_insert",
 			"Drupal 8+",
 			"",
 			"Respond to creation of a new entity of a particular type.",
@@ -811,13 +852,14 @@
 		"prefix": "hook_entity_update",
 		"body": [
 			"/**",
-			" * Implements hook_entity_update.",
+			" * Implements hook_entity_update().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_update(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_update",
 			"Drupal 8+",
 			"",
 			"Respond to updates to an entity.",
@@ -831,13 +873,14 @@
 		"prefix": "hook_ENTITY_TYPE_update",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_update.",
+			" * Implements hook_ENTITY_TYPE_update().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_update(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_update",
 			"Drupal 8+",
 			"",
 			"Respond to updates to an entity of a particular type.",
@@ -851,13 +894,14 @@
 		"prefix": "hook_entity_translation_create",
 		"body": [
 			"/**",
-			" * Implements hook_entity_translation_create.",
+			" * Implements hook_entity_translation_create().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_translation_create(\\Drupal\\Core\\Entity\\EntityInterface \\$translation) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_translation_create",
 			"Drupal 8+",
 			"",
 			"Acts when creating a new entity translation.",
@@ -870,13 +914,14 @@
 		"prefix": "hook_ENTITY_TYPE_translation_create",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_translation_create.",
+			" * Implements hook_ENTITY_TYPE_translation_create().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_translation_create(\\Drupal\\Core\\Entity\\EntityInterface \\$translation) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_translation_create",
 			"Drupal 8+",
 			"",
 			"Acts when creating a new entity translation of a specific type.",
@@ -889,13 +934,14 @@
 		"prefix": "hook_entity_translation_insert",
 		"body": [
 			"/**",
-			" * Implements hook_entity_translation_insert.",
+			" * Implements hook_entity_translation_insert().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_translation_insert(\\Drupal\\Core\\Entity\\EntityInterface \\$translation) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_translation_insert",
 			"Drupal 8+",
 			"",
 			"Respond to creation of a new entity translation.",
@@ -908,13 +954,14 @@
 		"prefix": "hook_ENTITY_TYPE_translation_insert",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_translation_insert.",
+			" * Implements hook_ENTITY_TYPE_translation_insert().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_translation_insert(\\Drupal\\Core\\Entity\\EntityInterface \\$translation) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_translation_insert",
 			"Drupal 8+",
 			"",
 			"Respond to creation of a new entity translation of a particular type.",
@@ -927,13 +974,14 @@
 		"prefix": "hook_entity_translation_delete",
 		"body": [
 			"/**",
-			" * Implements hook_entity_translation_delete.",
+			" * Implements hook_entity_translation_delete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_translation_delete(\\Drupal\\Core\\Entity\\EntityInterface \\$translation) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_translation_delete",
 			"Drupal 8+",
 			"",
 			"Respond to entity translation deletion.",
@@ -945,13 +993,14 @@
 		"prefix": "hook_ENTITY_TYPE_translation_delete",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_translation_delete.",
+			" * Implements hook_ENTITY_TYPE_translation_delete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_translation_delete(\\Drupal\\Core\\Entity\\EntityInterface \\$translation) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_translation_delete",
 			"Drupal 8+",
 			"",
 			"Respond to entity translation deletion of a particular type.",
@@ -963,13 +1012,14 @@
 		"prefix": "hook_entity_predelete",
 		"body": [
 			"/**",
-			" * Implements hook_entity_predelete.",
+			" * Implements hook_entity_predelete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_predelete(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_predelete",
 			"Drupal 8+",
 			"",
 			"Act before entity deletion."
@@ -980,13 +1030,14 @@
 		"prefix": "hook_ENTITY_TYPE_predelete",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_predelete.",
+			" * Implements hook_ENTITY_TYPE_predelete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_predelete(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_predelete",
 			"Drupal 8+",
 			"",
 			"Act before entity deletion of a particular entity type."
@@ -997,13 +1048,14 @@
 		"prefix": "hook_entity_delete",
 		"body": [
 			"/**",
-			" * Implements hook_entity_delete.",
+			" * Implements hook_entity_delete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_delete(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_delete",
 			"Drupal 8+",
 			"",
 			"Respond to entity deletion.",
@@ -1015,13 +1067,14 @@
 		"prefix": "hook_ENTITY_TYPE_delete",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_delete.",
+			" * Implements hook_ENTITY_TYPE_delete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_delete(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_delete",
 			"Drupal 8+",
 			"",
 			"Respond to entity deletion of a particular type.",
@@ -1033,13 +1086,14 @@
 		"prefix": "hook_entity_revision_delete",
 		"body": [
 			"/**",
-			" * Implements hook_entity_revision_delete.",
+			" * Implements hook_entity_revision_delete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_revision_delete(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_revision_delete",
 			"Drupal 8+",
 			"",
 			"Respond to entity revision deletion.",
@@ -1051,13 +1105,14 @@
 		"prefix": "hook_ENTITY_TYPE_revision_delete",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_revision_delete.",
+			" * Implements hook_ENTITY_TYPE_revision_delete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_revision_delete(Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_revision_delete",
 			"Drupal 8+",
 			"",
 			"Respond to entity revision deletion of a particular type.",
@@ -1069,13 +1124,14 @@
 		"prefix": "hook_entity_view",
 		"body": [
 			"/**",
-			" * Implements hook_entity_view.",
+			" * Implements hook_entity_view().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_view(array &\\$build, \\Drupal\\Core\\Entity\\EntityInterface \\$entity, \\Drupal\\Core\\Entity\\Display\\EntityViewDisplayInterface \\$display, \\$view_mode) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_view",
 			"Drupal 8+",
 			"",
 			"Act on entities being assembled before rendering."
@@ -1086,13 +1142,14 @@
 		"prefix": "hook_ENTITY_TYPE_view",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_view.",
+			" * Implements hook_ENTITY_TYPE_view().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_view(array &\\$build, \\Drupal\\Core\\Entity\\EntityInterface \\$entity, \\Drupal\\Core\\Entity\\Display\\EntityViewDisplayInterface \\$display, \\$view_mode) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_view",
 			"Drupal 8+",
 			"",
 			"Act on entities of a particular type being assembled before rendering."
@@ -1103,13 +1160,14 @@
 		"prefix": "hook_entity_view_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_view_alter.",
+			" * Implements hook_entity_view_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_view_alter(array &\\$build, Drupal\\Core\\Entity\\EntityInterface \\$entity, \\Drupal\\Core\\Entity\\Display\\EntityViewDisplayInterface \\$display) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_view_alter",
 			"Drupal 8+",
 			"",
 			"Alter the results of the entity build array.",
@@ -1128,13 +1186,14 @@
 		"prefix": "hook_ENTITY_TYPE_view_alter",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_view_alter.",
+			" * Implements hook_ENTITY_TYPE_view_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_view_alter(array &\\$build, Drupal\\Core\\Entity\\EntityInterface \\$entity, \\Drupal\\Core\\Entity\\Display\\EntityViewDisplayInterface \\$display) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_view_alter",
 			"Drupal 8+",
 			"",
 			"Alter the results of the entity build array for a particular entity type.",
@@ -1153,13 +1212,14 @@
 		"prefix": "hook_entity_prepare_view",
 		"body": [
 			"/**",
-			" * Implements hook_entity_prepare_view.",
+			" * Implements hook_entity_prepare_view().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_prepare_view(\\$entity_type_id, array \\$entities, array \\$displays, \\$view_mode) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_prepare_view",
 			"Drupal 8+",
 			"",
 			"Act on entities as they are being prepared for view.",
@@ -1173,13 +1233,14 @@
 		"prefix": "hook_entity_view_mode_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_view_mode_alter.",
+			" * Implements hook_entity_view_mode_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_view_mode_alter(&\\$view_mode, Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_view_mode_alter",
 			"Drupal 8+",
 			"",
 			"Change the view mode of an entity that is being displayed."
@@ -1190,13 +1251,14 @@
 		"prefix": "hook_ENTITY_TYPE_build_defaults_alter",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_build_defaults_alter.",
+			" * Implements hook_ENTITY_TYPE_build_defaults_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_build_defaults_alter(array &\\$build, \\Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$view_mode) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_build_defaults_alter",
 			"Drupal 8+",
 			"",
 			"Alter entity renderable values before cache checking in drupal_render().",
@@ -1211,13 +1273,14 @@
 		"prefix": "hook_entity_build_defaults_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_build_defaults_alter.",
+			" * Implements hook_entity_build_defaults_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_build_defaults_alter(array &\\$build, \\Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$view_mode) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_build_defaults_alter",
 			"Drupal 8+",
 			"",
 			"Alter entity renderable values before cache checking in drupal_render().",
@@ -1231,13 +1294,14 @@
 		"prefix": "hook_entity_view_display_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_view_display_alter.",
+			" * Implements hook_entity_view_display_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_view_display_alter(\\Drupal\\Core\\Entity\\Display\\EntityViewDisplayInterface \\$display, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_view_display_alter",
 			"Drupal 8+",
 			"",
 			"Alter the settings used for displaying an entity."
@@ -1248,13 +1312,14 @@
 		"prefix": "hook_entity_display_build_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_display_build_alter.",
+			" * Implements hook_entity_display_build_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_display_build_alter(&\\$build, \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_display_build_alter",
 			"Drupal 8+",
 			"",
 			"Alter the render array generated by an EntityDisplay for an entity."
@@ -1265,13 +1330,14 @@
 		"prefix": "hook_entity_prepare_form",
 		"body": [
 			"/**",
-			" * Implements hook_entity_prepare_form.",
+			" * Implements hook_entity_prepare_form().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_prepare_form(\\Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$operation, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_prepare_form",
 			"Drupal 8+",
 			"",
 			"Acts on an entity object about to be shown on an entity form.",
@@ -1285,13 +1351,14 @@
 		"prefix": "hook_ENTITY_TYPE_prepare_form",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_prepare_form.",
+			" * Implements hook_ENTITY_TYPE_prepare_form().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_prepare_form(\\Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$operation, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_prepare_form",
 			"Drupal 8+",
 			"",
 			"Acts on a particular type of entity object about to be in an entity form.",
@@ -1305,13 +1372,14 @@
 		"prefix": "hook_entity_form_display_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_form_display_alter.",
+			" * Implements hook_entity_form_display_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_form_display_alter(\\Drupal\\Core\\Entity\\Display\\EntityFormDisplayInterface \\$form_display, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_form_display_alter",
 			"Drupal 8+",
 			"",
 			"Alter the settings used for displaying an entity form."
@@ -1322,13 +1390,14 @@
 		"prefix": "hook_entity_base_field_info",
 		"body": [
 			"/**",
-			" * Implements hook_entity_base_field_info.",
+			" * Implements hook_entity_base_field_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_base_field_info(\\Drupal\\Core\\Entity\\EntityTypeInterface \\$entity_type) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_base_field_info",
 			"Drupal 8+",
 			"",
 			"Provides custom base field definitions for a content entity type.",
@@ -1343,13 +1412,14 @@
 		"prefix": "hook_entity_base_field_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_base_field_info_alter.",
+			" * Implements hook_entity_base_field_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_base_field_info_alter(&\\$fields, \\Drupal\\Core\\Entity\\EntityTypeInterface \\$entity_type) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_base_field_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter base field definitions for a content entity type."
@@ -1360,13 +1430,14 @@
 		"prefix": "hook_entity_bundle_field_info",
 		"body": [
 			"/**",
-			" * Implements hook_entity_bundle_field_info.",
+			" * Implements hook_entity_bundle_field_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_bundle_field_info(\\Drupal\\Core\\Entity\\EntityTypeInterface \\$entity_type, \\$bundle, array \\$base_field_definitions) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_bundle_field_info",
 			"Drupal 8+",
 			"",
 			"Provides field definitions for a specific bundle within an entity type.",
@@ -1380,13 +1451,14 @@
 		"prefix": "hook_entity_bundle_field_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_bundle_field_info_alter.",
+			" * Implements hook_entity_bundle_field_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_bundle_field_info_alter(&\\$fields, \\Drupal\\Core\\Entity\\EntityTypeInterface \\$entity_type, \\$bundle) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_bundle_field_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter bundle field definitions."
@@ -1397,13 +1469,14 @@
 		"prefix": "hook_entity_field_storage_info",
 		"body": [
 			"/**",
-			" * Implements hook_entity_field_storage_info.",
+			" * Implements hook_entity_field_storage_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_field_storage_info(\\Drupal\\Core\\Entity\\EntityTypeInterface \\$entity_type) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_field_storage_info",
 			"Drupal 8+",
 			"",
 			"Provides field storage definitions for a content entity type.",
@@ -1418,13 +1491,14 @@
 		"prefix": "hook_entity_field_storage_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_field_storage_info_alter.",
+			" * Implements hook_entity_field_storage_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_field_storage_info_alter(&\\$fields, \\Drupal\\Core\\Entity\\EntityTypeInterface \\$entity_type) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_field_storage_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter field storage definitions for a content entity type."
@@ -1435,13 +1509,14 @@
 		"prefix": "hook_entity_operation",
 		"body": [
 			"/**",
-			" * Implements hook_entity_operation.",
+			" * Implements hook_entity_operation().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_operation(\\Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_operation",
 			"Drupal 8+",
 			"",
 			"Declares entity operations."
@@ -1452,13 +1527,14 @@
 		"prefix": "hook_entity_operation_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_operation_alter.",
+			" * Implements hook_entity_operation_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_operation_alter(array &\\$operations, \\Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_operation_alter",
 			"Drupal 8+",
 			"",
 			"Alter entity operations."
@@ -1469,13 +1545,14 @@
 		"prefix": "hook_entity_field_access",
 		"body": [
 			"/**",
-			" * Implements hook_entity_field_access.",
+			" * Implements hook_entity_field_access().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_field_access(\\$operation, \\Drupal\\Core\\Field\\FieldDefinitionInterface \\$field_definition, \\Drupal\\Core\\Session\\AccountInterface \\$account, \\Drupal\\Core\\Field\\FieldItemListInterface \\$items = NULL) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_field_access",
 			"Drupal 8+",
 			"",
 			"Control access to fields.",
@@ -1489,13 +1566,14 @@
 		"prefix": "hook_entity_field_access_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_field_access_alter.",
+			" * Implements hook_entity_field_access_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_field_access_alter(array &\\$grants, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_field_access_alter",
 			"Drupal 8+",
 			"",
 			"Alter the default access behavior for a given field.",
@@ -1508,13 +1586,14 @@
 		"prefix": "hook_entity_field_values_init",
 		"body": [
 			"/**",
-			" * Implements hook_entity_field_values_init.",
+			" * Implements hook_entity_field_values_init().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_field_values_init(\\Drupal\\Core\\Entity\\FieldableEntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_field_values_init",
 			"Drupal 8+",
 			"",
 			"Acts when initializing a fieldable entity object.",
@@ -1528,13 +1607,14 @@
 		"prefix": "hook_ENTITY_TYPE_field_values_init",
 		"body": [
 			"/**",
-			" * Implements hook_ENTITY_TYPE_field_values_init.",
+			" * Implements hook_ENTITY_TYPE_field_values_init().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${2:ENTITY_TYPE}_field_values_init(\\Drupal\\Core\\Entity\\FieldableEntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ENTITY_TYPE_field_values_init",
 			"Drupal 8+",
 			"",
 			"Acts when initializing a fieldable entity object.",
@@ -1548,13 +1628,14 @@
 		"prefix": "hook_entity_extra_field_info",
 		"body": [
 			"/**",
-			" * Implements hook_entity_extra_field_info.",
+			" * Implements hook_entity_extra_field_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_extra_field_info() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_extra_field_info",
 			"Drupal 8+",
 			"",
 			"Exposes \"pseudo-field\" components on content entities.",
@@ -1572,13 +1653,14 @@
 		"prefix": "hook_entity_extra_field_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_entity_extra_field_info_alter.",
+			" * Implements hook_entity_extra_field_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_entity_extra_field_info_alter(&\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_entity_extra_field_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter \"pseudo-field\" components on content entities."
@@ -1589,13 +1671,14 @@
 		"prefix": "hook_hook_info",
 		"body": [
 			"/**",
-			" * Implements hook_hook_info.",
+			" * Implements hook_hook_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_${1:${TM_FILENAME_BASE:hook}}_info() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_hook_info",
 			"Drupal 8+",
 			"",
 			"Defines one or more hooks that are exposed by a module.",
@@ -1616,13 +1699,14 @@
 		"prefix": "hook_module_implements_alter",
 		"body": [
 			"/**",
-			" * Implements hook_module_implements_alter.",
+			" * Implements hook_module_implements_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_module_implements_alter(&\\$implementations, \\$hook) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_module_implements_alter",
 			"Drupal 8+",
 			"",
 			"Alter the registry of modules implementing a hook.",
@@ -1644,13 +1728,14 @@
 		"prefix": "hook_system_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_system_info_alter.",
+			" * Implements hook_system_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_system_info_alter(array &\\$info, \\Drupal\\Core\\Extension\\Extension \\$file, \\$type) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_system_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the information parsed from module and theme .info.yml files.",
@@ -1668,13 +1753,14 @@
 		"prefix": "hook_module_preinstall",
 		"body": [
 			"/**",
-			" * Implements hook_module_preinstall.",
+			" * Implements hook_module_preinstall().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_module_preinstall(\\$module) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_module_preinstall",
 			"Drupal 8+",
 			"",
 			"Perform necessary actions before a module is installed."
@@ -1685,13 +1771,14 @@
 		"prefix": "hook_modules_installed",
 		"body": [
 			"/**",
-			" * Implements hook_modules_installed.",
+			" * Implements hook_modules_installed().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_modules_installed(\\$modules, \\$is_syncing) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_modules_installed",
 			"Drupal 8+",
 			"",
 			"Perform necessary actions after modules are installed.",
@@ -1708,13 +1795,14 @@
 		"prefix": "hook_install",
 		"body": [
 			"/**",
-			" * Implements hook_install.",
+			" * Implements hook_install().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_install(\\$is_syncing) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_install",
 			"Drupal 8+",
 			"",
 			"Perform setup tasks when the module is installed.",
@@ -1739,13 +1827,14 @@
 		"prefix": "hook_module_preuninstall",
 		"body": [
 			"/**",
-			" * Implements hook_module_preuninstall.",
+			" * Implements hook_module_preuninstall().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_module_preuninstall(\\$module) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_module_preuninstall",
 			"Drupal 8+",
 			"",
 			"Perform necessary actions before a module is uninstalled."
@@ -1756,13 +1845,14 @@
 		"prefix": "hook_modules_uninstalled",
 		"body": [
 			"/**",
-			" * Implements hook_modules_uninstalled.",
+			" * Implements hook_modules_uninstalled().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_modules_uninstalled(\\$modules, \\$is_syncing) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_modules_uninstalled",
 			"Drupal 8+",
 			"",
 			"Perform necessary actions after modules are uninstalled.",
@@ -1778,13 +1868,14 @@
 		"prefix": "hook_uninstall",
 		"body": [
 			"/**",
-			" * Implements hook_uninstall.",
+			" * Implements hook_uninstall().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_uninstall(\\$is_syncing) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_uninstall",
 			"Drupal 8+",
 			"",
 			"Remove any information that the module sets.",
@@ -1804,13 +1895,14 @@
 		"prefix": "hook_install_tasks",
 		"body": [
 			"/**",
-			" * Implements hook_install_tasks.",
+			" * Implements hook_install_tasks().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_install_tasks(&\\$install_state) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_install_tasks",
 			"Drupal 8+",
 			"",
 			"Return an array of tasks to be performed by an installation profile.",
@@ -1860,13 +1952,14 @@
 		"prefix": "hook_install_tasks_alter",
 		"body": [
 			"/**",
-			" * Implements hook_install_tasks_alter.",
+			" * Implements hook_install_tasks_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_install_tasks_alter(&\\$tasks, \\$install_state) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_install_tasks_alter",
 			"Drupal 8+",
 			"",
 			"Alter the full list of installation tasks.",
@@ -1880,13 +1973,14 @@
 		"prefix": "hook_update_N",
 		"body": [
 			"/**",
-			" * Implements hook_update_N.",
+			" * Implements hook_update_N().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_update_${2:N}() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_update_N",
 			"Drupal 8+",
 			"",
 			"Perform a single update between minor versions.",
@@ -1900,13 +1994,14 @@
 		"prefix": "hook_post_update_NAME",
 		"body": [
 			"/**",
-			" * Implements hook_post_update_NAME.",
+			" * Implements hook_post_update_NAME().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_post_update_${2:NAME}(&\\$sandbox) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_post_update_NAME",
 			"Drupal 8+",
 			"",
 			"Executes an update which is intended to update data, like entities.",
@@ -1926,13 +2021,14 @@
 		"prefix": "hook_removed_post_updates",
 		"body": [
 			"/**",
-			" * Implements hook_removed_post_updates.",
+			" * Implements hook_removed_post_updates().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_removed_post_updates() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_removed_post_updates",
 			"Drupal 8+",
 			"",
 			"Return an array of removed hook_post_update_NAME() function names.",
@@ -1946,13 +2042,14 @@
 		"prefix": "hook_update_dependencies",
 		"body": [
 			"/**",
-			" * Implements hook_update_dependencies.",
+			" * Implements hook_update_dependencies().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_update_dependencies() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_update_dependencies",
 			"Drupal 8+",
 			"",
 			"Return an array of information about module update dependencies.",
@@ -1969,13 +2066,14 @@
 		"prefix": "hook_update_last_removed",
 		"body": [
 			"/**",
-			" * Implements hook_update_last_removed.",
+			" * Implements hook_update_last_removed().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_update_last_removed() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_update_last_removed",
 			"Drupal 8+",
 			"",
 			"Return a number which is no longer available as hook_update_N().",
@@ -1991,13 +2089,14 @@
 		"prefix": "hook_updater_info",
 		"body": [
 			"/**",
-			" * Implements hook_updater_info.",
+			" * Implements hook_updater_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_updater_info() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_updater_info",
 			"Drupal 8+",
 			"",
 			"Provide information on Updaters (classes that can update Drupal).",
@@ -2011,13 +2110,14 @@
 		"prefix": "hook_updater_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_updater_info_alter.",
+			" * Implements hook_updater_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_updater_info_alter(&\\$updaters) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_updater_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the Updater information array.",
@@ -2031,13 +2131,14 @@
 		"prefix": "hook_requirements",
 		"body": [
 			"/**",
-			" * Implements hook_requirements.",
+			" * Implements hook_requirements().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_requirements(\\$phase) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_requirements",
 			"Drupal 8+",
 			"",
 			"Check installation requirements and do status reporting.",
@@ -2075,13 +2176,14 @@
 		"prefix": "hook_file_download",
 		"body": [
 			"/**",
-			" * Implements hook_file_download.",
+			" * Implements hook_file_download().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_file_download(\\$uri) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_file_download",
 			"Drupal 8+",
 			"",
 			"Control access to private file downloads and specify HTTP headers.",
@@ -2096,13 +2198,14 @@
 		"prefix": "hook_file_url_alter",
 		"body": [
 			"/**",
-			" * Implements hook_file_url_alter.",
+			" * Implements hook_file_url_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_file_url_alter(&\\$uri) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_file_url_alter",
 			"Drupal 8+",
 			"",
 			"Alter the URL to a file.",
@@ -2119,13 +2222,14 @@
 		"prefix": "hook_file_mimetype_mapping_alter",
 		"body": [
 			"/**",
-			" * Implements hook_file_mimetype_mapping_alter.",
+			" * Implements hook_file_mimetype_mapping_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_file_mimetype_mapping_alter(&\\$mapping) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_file_mimetype_mapping_alter",
 			"Drupal 8+",
 			"",
 			"Alter MIME type mappings used to determine MIME type from a file extension.",
@@ -2139,13 +2243,14 @@
 		"prefix": "hook_archiver_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_archiver_info_alter.",
+			" * Implements hook_archiver_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_archiver_info_alter(&\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_archiver_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter archiver information declared by other modules.",
@@ -2158,13 +2263,14 @@
 		"prefix": "hook_filetransfer_info",
 		"body": [
 			"/**",
-			" * Implements hook_filetransfer_info.",
+			" * Implements hook_filetransfer_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_filetransfer_info() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_filetransfer_info",
 			"Drupal 8+",
 			"",
 			"Register information about FileTransfer classes provided by a module.",
@@ -2182,13 +2288,14 @@
 		"prefix": "hook_filetransfer_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_filetransfer_info_alter.",
+			" * Implements hook_filetransfer_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_filetransfer_info_alter(&\\$filetransfer_info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_filetransfer_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the FileTransfer class registry."
@@ -2199,13 +2306,14 @@
 		"prefix": "hook_ajax_render_alter",
 		"body": [
 			"/**",
-			" * Implements hook_ajax_render_alter.",
+			" * Implements hook_ajax_render_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_ajax_render_alter(array &\\$data) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ajax_render_alter",
 			"Drupal 8+",
 			"",
 			"Alter the Ajax command data that is sent to the client."
@@ -2216,13 +2324,14 @@
 		"prefix": "hook_form_alter",
 		"body": [
 			"/**",
-			" * Implements hook_form_alter.",
+			" * Implements hook_form_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_form_alter(&\\$form, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state, \\$form_id) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_form_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations before a form is rendered.",
@@ -2251,13 +2360,14 @@
 		"prefix": "hook_form_FORM_ID_alter",
 		"body": [
 			"/**",
-			" * Implements hook_form_FORM_ID_alter.",
+			" * Implements hook_form_FORM_ID_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_form_${2:FORM_ID}_alter(&\\$form, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state, \\$form_id) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_form_FORM_ID_alter",
 			"Drupal 8+",
 			"",
 			"Provide a form-specific alteration instead of the global hook_form_alter().",
@@ -2276,13 +2386,14 @@
 		"prefix": "hook_form_BASE_FORM_ID_alter",
 		"body": [
 			"/**",
-			" * Implements hook_form_BASE_FORM_ID_alter.",
+			" * Implements hook_form_BASE_FORM_ID_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_form_${2:BASE_FORM_ID}_alter(&\\$form, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state, \\$form_id) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_form_BASE_FORM_ID_alter",
 			"Drupal 8+",
 			"",
 			"Provide a form-specific alteration for shared ('base') forms.",
@@ -2308,13 +2419,14 @@
 		"prefix": "hook_batch_alter",
 		"body": [
 			"/**",
-			" * Implements hook_batch_alter.",
+			" * Implements hook_batch_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_batch_alter(&\\$batch) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_batch_alter",
 			"Drupal 8+",
 			"",
 			"Alter batch information before a batch is processed.",
@@ -2327,13 +2439,14 @@
 		"prefix": "hook_language_switch_links_alter",
 		"body": [
 			"/**",
-			" * Implements hook_language_switch_links_alter.",
+			" * Implements hook_language_switch_links_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_language_switch_links_alter(array &\\$links, \\$type, \\Drupal\\Core\\Url \\$url) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_language_switch_links_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on language switcher links.",
@@ -2347,13 +2460,14 @@
 		"prefix": "hook_transliteration_overrides_alter",
 		"body": [
 			"/**",
-			" * Implements hook_transliteration_overrides_alter.",
+			" * Implements hook_transliteration_overrides_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_transliteration_overrides_alter(&\\$overrides, \\$langcode) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_transliteration_overrides_alter",
 			"Drupal 8+",
 			"",
 			"Provide language-specific overrides for transliteration.",
@@ -2369,13 +2483,14 @@
 		"prefix": "hook_menu_links_discovered_alter",
 		"body": [
 			"/**",
-			" * Implements hook_menu_links_discovered_alter.",
+			" * Implements hook_menu_links_discovered_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_menu_links_discovered_alter(&\\$links) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_menu_links_discovered_alter",
 			"Drupal 8+",
 			"",
 			"Alters all the menu links discovered by the menu link plugin manager."
@@ -2386,13 +2501,14 @@
 		"prefix": "hook_menu_local_tasks_alter",
 		"body": [
 			"/**",
-			" * Implements hook_menu_local_tasks_alter.",
+			" * Implements hook_menu_local_tasks_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_menu_local_tasks_alter(&\\$data, \\$route_name, \\Drupal\\Core\\Cache\\RefinableCacheableDependencyInterface &\\$cacheability) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_menu_local_tasks_alter",
 			"Drupal 8+",
 			"",
 			"Alter local tasks displayed on the page before they are rendered.",
@@ -2416,13 +2532,14 @@
 		"prefix": "hook_menu_local_actions_alter",
 		"body": [
 			"/**",
-			" * Implements hook_menu_local_actions_alter.",
+			" * Implements hook_menu_local_actions_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_menu_local_actions_alter(&\\$local_actions) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_menu_local_actions_alter",
 			"Drupal 8+",
 			"",
 			"Alter local actions plugins."
@@ -2433,13 +2550,14 @@
 		"prefix": "hook_local_tasks_alter",
 		"body": [
 			"/**",
-			" * Implements hook_local_tasks_alter.",
+			" * Implements hook_local_tasks_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_local_tasks_alter(&\\$local_tasks) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_local_tasks_alter",
 			"Drupal 8+",
 			"",
 			"Alter local tasks plugins."
@@ -2450,13 +2568,14 @@
 		"prefix": "hook_contextual_links_alter",
 		"body": [
 			"/**",
-			" * Implements hook_contextual_links_alter.",
+			" * Implements hook_contextual_links_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_contextual_links_alter(array &\\$links, \\$group, array \\$route_parameters) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_contextual_links_alter",
 			"Drupal 8+",
 			"",
 			"Alter contextual links before they are rendered.",
@@ -2477,13 +2596,14 @@
 		"prefix": "hook_contextual_links_plugins_alter",
 		"body": [
 			"/**",
-			" * Implements hook_contextual_links_plugins_alter.",
+			" * Implements hook_contextual_links_plugins_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_contextual_links_plugins_alter(array &\\$contextual_links) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_contextual_links_plugins_alter",
 			"Drupal 8+",
 			"",
 			"Alter the plugin definition of contextual links."
@@ -2494,13 +2614,14 @@
 		"prefix": "hook_system_breadcrumb_alter",
 		"body": [
 			"/**",
-			" * Implements hook_system_breadcrumb_alter.",
+			" * Implements hook_system_breadcrumb_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_system_breadcrumb_alter(\\Drupal\\Core\\Breadcrumb\\Breadcrumb &\\$breadcrumb, \\Drupal\\Core\\Routing\\RouteMatchInterface \\$route_match, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_system_breadcrumb_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations to the breadcrumb built by the BreadcrumbManager."
@@ -2511,13 +2632,14 @@
 		"prefix": "hook_link_alter",
 		"body": [
 			"/**",
-			" * Implements hook_link_alter.",
+			" * Implements hook_link_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_link_alter(&\\$variables) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_link_alter",
 			"Drupal 8+",
 			"",
 			"Alter the parameters for links."
@@ -2528,13 +2650,14 @@
 		"prefix": "hook_plugin_filter_TYPE_alter",
 		"body": [
 			"/**",
-			" * Implements hook_plugin_filter_TYPE_alter.",
+			" * Implements hook_plugin_filter_TYPE_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_plugin_filter_${2:TYPE}_alter(array &\\$definitions, array \\$extra, \\$consumer) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_plugin_filter_TYPE_alter",
 			"Drupal 8+",
 			"",
 			"Alter the filtering of plugin definitions for a specific plugin type.",
@@ -2549,13 +2672,14 @@
 		"prefix": "hook_plugin_filter_TYPE__CONSUMER_alter",
 		"body": [
 			"/**",
-			" * Implements hook_plugin_filter_TYPE__CONSUMER_alter.",
+			" * Implements hook_plugin_filter_TYPE__CONSUMER_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_plugin_filter_${2:TYPE}__${3:CONSUMER}_alter(array &\\$definitions, array \\$extra) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_plugin_filter_TYPE__CONSUMER_alter",
 			"Drupal 8+",
 			"",
 			"Alter the filtering of plugin definitions for a specific type and consumer.",
@@ -2573,13 +2697,14 @@
 		"prefix": "hook_form_system_theme_settings_alter",
 		"body": [
 			"/**",
-			" * Implements hook_form_system_theme_settings_alter.",
+			" * Implements hook_form_system_theme_settings_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_form_system_theme_settings_alter(&\\$form, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_form_system_theme_settings_alter",
 			"Drupal 8+",
 			"",
 			"Allow themes to alter the theme-specific settings form.",
@@ -2596,13 +2721,14 @@
 		"prefix": "hook_preprocess",
 		"body": [
 			"/**",
-			" * Implements hook_preprocess.",
+			" * Implements hook_preprocess().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_preprocess(&\\$variables, \\$hook) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_preprocess",
 			"Drupal 8+",
 			"",
 			"Preprocess theme variables for templates.",
@@ -2619,13 +2745,14 @@
 		"prefix": "hook_preprocess_HOOK",
 		"body": [
 			"/**",
-			" * Implements hook_preprocess_HOOK.",
+			" * Implements hook_preprocess_HOOK().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_preprocess_${2:HOOK}(&\\$variables) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_preprocess_HOOK",
 			"Drupal 8+",
 			"",
 			"Preprocess theme variables for a specific theme hook.",
@@ -2640,13 +2767,14 @@
 		"prefix": "hook_theme_suggestions_HOOK",
 		"body": [
 			"/**",
-			" * Implements hook_theme_suggestions_HOOK.",
+			" * Implements hook_theme_suggestions_HOOK().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_theme_suggestions_${2:HOOK}(array \\$variables) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_theme_suggestions_HOOK",
 			"Drupal 8+",
 			"",
 			"Provides alternate named suggestions for a specific theme hook.",
@@ -2667,13 +2795,14 @@
 		"prefix": "hook_theme_suggestions_alter",
 		"body": [
 			"/**",
-			" * Implements hook_theme_suggestions_alter.",
+			" * Implements hook_theme_suggestions_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_theme_suggestions_alter(array &\\$suggestions, array \\$variables, \\$hook) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_theme_suggestions_alter",
 			"Drupal 8+",
 			"",
 			"Alters named suggestions for all theme hooks.",
@@ -2696,13 +2825,14 @@
 		"prefix": "hook_theme_suggestions_HOOK_alter",
 		"body": [
 			"/**",
-			" * Implements hook_theme_suggestions_HOOK_alter.",
+			" * Implements hook_theme_suggestions_HOOK_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_theme_suggestions_${2:HOOK}_alter(array &\\$suggestions, array \\$variables) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_theme_suggestions_HOOK_alter",
 			"Drupal 8+",
 			"",
 			"Alters named suggestions for a specific theme hook.",
@@ -2724,13 +2854,14 @@
 		"prefix": "hook_themes_installed",
 		"body": [
 			"/**",
-			" * Implements hook_themes_installed.",
+			" * Implements hook_themes_installed().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_themes_installed(\\$theme_list) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_themes_installed",
 			"Drupal 8+",
 			"",
 			"Respond to themes being installed."
@@ -2741,13 +2872,14 @@
 		"prefix": "hook_themes_uninstalled",
 		"body": [
 			"/**",
-			" * Implements hook_themes_uninstalled.",
+			" * Implements hook_themes_uninstalled().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_themes_uninstalled(array \\$themes) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_themes_uninstalled",
 			"Drupal 8+",
 			"",
 			"Respond to themes being uninstalled."
@@ -2758,13 +2890,14 @@
 		"prefix": "hook_extension",
 		"body": [
 			"/**",
-			" * Implements hook_extension.",
+			" * Implements hook_extension().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_extension() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_extension",
 			"Drupal 8+",
 			"",
 			"Declare a template file extension to be used with a theme engine.",
@@ -2777,13 +2910,14 @@
 		"prefix": "hook_render_template",
 		"body": [
 			"/**",
-			" * Implements hook_render_template.",
+			" * Implements hook_render_template().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_render_template(\\$template_file, \\$variables) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_render_template",
 			"Drupal 8+",
 			"",
 			"Render a template using the theme engine.",
@@ -2799,13 +2933,14 @@
 		"prefix": "hook_element_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_element_info_alter.",
+			" * Implements hook_element_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_element_info_alter(array &\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_element_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the element type information returned from modules.",
@@ -2818,13 +2953,14 @@
 		"prefix": "hook_element_plugin_alter",
 		"body": [
 			"/**",
-			" * Implements hook_element_plugin_alter.",
+			" * Implements hook_element_plugin_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_element_plugin_alter(array &\\$definitions) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_element_plugin_alter",
 			"Drupal 8+",
 			"",
 			"Alter Element plugin definitions.",
@@ -2838,13 +2974,14 @@
 		"prefix": "hook_js_alter",
 		"body": [
 			"/**",
-			" * Implements hook_js_alter.",
+			" * Implements hook_js_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_js_alter(&\\$javascript, \\Drupal\\Core\\Asset\\AttachedAssetsInterface \\$assets) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_js_alter",
 			"Drupal 8+",
 			"",
 			"Perform necessary alterations to the JavaScript before it is presented on",
@@ -2856,13 +2993,14 @@
 		"prefix": "hook_library_info_build",
 		"body": [
 			"/**",
-			" * Implements hook_library_info_build.",
+			" * Implements hook_library_info_build().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_library_info_build() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_library_info_build",
 			"Drupal 8+",
 			"",
 			"Add dynamic library definitions.",
@@ -2876,13 +3014,14 @@
 		"prefix": "hook_js_settings_build",
 		"body": [
 			"/**",
-			" * Implements hook_js_settings_build.",
+			" * Implements hook_js_settings_build().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_js_settings_build(array &\\$settings, \\Drupal\\Core\\Asset\\AttachedAssetsInterface \\$assets) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_js_settings_build",
 			"Drupal 8+",
 			"",
 			"Modify the JavaScript settings (drupalSettings)."
@@ -2893,13 +3032,14 @@
 		"prefix": "hook_js_settings_alter",
 		"body": [
 			"/**",
-			" * Implements hook_js_settings_alter.",
+			" * Implements hook_js_settings_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_js_settings_alter(array &\\$settings, \\Drupal\\Core\\Asset\\AttachedAssetsInterface \\$assets) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_js_settings_alter",
 			"Drupal 8+",
 			"",
 			"Perform necessary alterations to the JavaScript settings (drupalSettings)."
@@ -2910,13 +3050,14 @@
 		"prefix": "hook_library_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_library_info_alter.",
+			" * Implements hook_library_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_library_info_alter(&\\$libraries, \\$extension) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_library_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter libraries provided by an extension.",
@@ -2932,13 +3073,14 @@
 		"prefix": "hook_css_alter",
 		"body": [
 			"/**",
-			" * Implements hook_css_alter.",
+			" * Implements hook_css_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_css_alter(&\\$css, \\Drupal\\Core\\Asset\\AttachedAssetsInterface \\$assets) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_css_alter",
 			"Drupal 8+",
 			"",
 			"Alter CSS files before they are output on the page."
@@ -2949,13 +3091,14 @@
 		"prefix": "hook_page_attachments",
 		"body": [
 			"/**",
-			" * Implements hook_page_attachments.",
+			" * Implements hook_page_attachments().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_page_attachments(array &\\$attachments) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_page_attachments",
 			"Drupal 8+",
 			"",
 			"Add attachments (typically assets) to a page before it is rendered.",
@@ -2972,13 +3115,14 @@
 		"prefix": "hook_page_attachments_alter",
 		"body": [
 			"/**",
-			" * Implements hook_page_attachments_alter.",
+			" * Implements hook_page_attachments_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_page_attachments_alter(array &\\$attachments) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_page_attachments_alter",
 			"Drupal 8+",
 			"",
 			"Alter attachments (typically assets) to a page before it is rendered.",
@@ -2994,13 +3138,14 @@
 		"prefix": "hook_page_top",
 		"body": [
 			"/**",
-			" * Implements hook_page_top.",
+			" * Implements hook_page_top().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_page_top(array &\\$page_top) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_page_top",
 			"Drupal 8+",
 			"",
 			"Add a renderable array to the top of the page."
@@ -3011,13 +3156,14 @@
 		"prefix": "hook_page_bottom",
 		"body": [
 			"/**",
-			" * Implements hook_page_bottom.",
+			" * Implements hook_page_bottom().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_page_bottom(array &\\$page_bottom) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_page_bottom",
 			"Drupal 8+",
 			"",
 			"Add a renderable array to the bottom of the page."
@@ -3028,13 +3174,14 @@
 		"prefix": "hook_theme",
 		"body": [
 			"/**",
-			" * Implements hook_theme.",
+			" * Implements hook_theme().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_theme(\\$existing, \\$type, \\$theme, \\$path) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_theme",
 			"Drupal 8+",
 			"",
 			"Register a module or theme's theme implementations.",
@@ -3047,13 +3194,14 @@
 		"prefix": "hook_theme_registry_alter",
 		"body": [
 			"/**",
-			" * Implements hook_theme_registry_alter.",
+			" * Implements hook_theme_registry_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_theme_registry_alter(&\\$theme_registry) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_theme_registry_alter",
 			"Drupal 8+",
 			"",
 			"Alter the theme registry information returned from hook_theme().",
@@ -3073,13 +3221,14 @@
 		"prefix": "hook_template_preprocess_default_variables_alter",
 		"body": [
 			"/**",
-			" * Implements hook_template_preprocess_default_variables_alter.",
+			" * Implements hook_template_preprocess_default_variables_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_template_preprocess_default_variables_alter(&\\$variables) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_template_preprocess_default_variables_alter",
 			"Drupal 8+",
 			"",
 			"Alter the default, hook-independent variables for all templates.",
@@ -3098,13 +3247,14 @@
 		"prefix": "hook_tokens",
 		"body": [
 			"/**",
-			" * Implements hook_tokens.",
+			" * Implements hook_tokens().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_tokens(\\$type, \\$tokens, array \\$data, array \\$options, \\Drupal\\Core\\Render\\BubbleableMetadata \\$bubbleable_metadata) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_tokens",
 			"Drupal 8+",
 			"",
 			"Provide replacement values for placeholder tokens.",
@@ -3123,13 +3273,14 @@
 		"prefix": "hook_tokens_alter",
 		"body": [
 			"/**",
-			" * Implements hook_tokens_alter.",
+			" * Implements hook_tokens_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_tokens_alter(array &\\$replacements, array \\$context, \\Drupal\\Core\\Render\\BubbleableMetadata \\$bubbleable_metadata) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_tokens_alter",
 			"Drupal 8+",
 			"",
 			"Alter replacement values for placeholder tokens."
@@ -3140,13 +3291,14 @@
 		"prefix": "hook_token_info",
 		"body": [
 			"/**",
-			" * Implements hook_token_info.",
+			" * Implements hook_token_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_token_info() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_token_info",
 			"Drupal 8+",
 			"",
 			"Provide information about available placeholder tokens and token types.",
@@ -3166,13 +3318,14 @@
 		"prefix": "hook_token_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_token_info_alter.",
+			" * Implements hook_token_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_token_info_alter(&\\$data) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_token_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the metadata about available placeholder tokens and token types."
@@ -3183,13 +3336,14 @@
 		"prefix": "hook_aggregator_fetcher_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_aggregator_fetcher_info_alter.",
+			" * Implements hook_aggregator_fetcher_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_aggregator_fetcher_info_alter(array &\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_aggregator_fetcher_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on the available fetchers."
@@ -3200,13 +3354,14 @@
 		"prefix": "hook_aggregator_parser_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_aggregator_parser_info_alter.",
+			" * Implements hook_aggregator_parser_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_aggregator_parser_info_alter(array &\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_aggregator_parser_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on the available parsers."
@@ -3217,13 +3372,14 @@
 		"prefix": "hook_aggregator_processor_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_aggregator_processor_info_alter.",
+			" * Implements hook_aggregator_processor_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_aggregator_processor_info_alter(array &\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_aggregator_processor_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on the available processors."
@@ -3234,13 +3390,14 @@
 		"prefix": "hook_block_view_alter",
 		"body": [
 			"/**",
-			" * Implements hook_block_view_alter.",
+			" * Implements hook_block_view_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_block_view_alter(array &\\$build, \\Drupal\\Core\\Block\\BlockPluginInterface \\$block) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_block_view_alter",
 			"Drupal 8+",
 			"",
 			"Alter the result of \\Drupal\\Core\\Block\\BlockBase::build().",
@@ -3258,13 +3415,14 @@
 		"prefix": "hook_block_view_BASE_BLOCK_ID_alter",
 		"body": [
 			"/**",
-			" * Implements hook_block_view_BASE_BLOCK_ID_alter.",
+			" * Implements hook_block_view_BASE_BLOCK_ID_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_block_view_${2:BASE_BLOCK_ID}_alter(array &\\$build, \\Drupal\\Core\\Block\\BlockPluginInterface \\$block) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_block_view_BASE_BLOCK_ID_alter",
 			"Drupal 8+",
 			"",
 			"Provide a block plugin specific block_view alteration.",
@@ -3282,13 +3440,14 @@
 		"prefix": "hook_block_build_alter",
 		"body": [
 			"/**",
-			" * Implements hook_block_build_alter.",
+			" * Implements hook_block_build_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_block_build_alter(array &\\$build, \\Drupal\\Core\\Block\\BlockPluginInterface \\$block) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_block_build_alter",
 			"Drupal 8+",
 			"",
 			"Alter the result of \\Drupal\\Core\\Block\\BlockBase::build().",
@@ -3306,13 +3465,14 @@
 		"prefix": "hook_block_build_BASE_BLOCK_ID_alter",
 		"body": [
 			"/**",
-			" * Implements hook_block_build_BASE_BLOCK_ID_alter.",
+			" * Implements hook_block_build_BASE_BLOCK_ID_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_block_build_${2:BASE_BLOCK_ID}_alter(array &\\$build, \\Drupal\\Core\\Block\\BlockPluginInterface \\$block) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_block_build_BASE_BLOCK_ID_alter",
 			"Drupal 8+",
 			"",
 			"Provide a block plugin specific block_build alteration.",
@@ -3330,13 +3490,14 @@
 		"prefix": "hook_block_access",
 		"body": [
 			"/**",
-			" * Implements hook_block_access.",
+			" * Implements hook_block_access().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_block_access(\\Drupal\\block\\Entity\\Block \\$block, \\$operation, \\Drupal\\Core\\Session\\AccountInterface \\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_block_access",
 			"Drupal 8+",
 			"",
 			"Control access to a block instance.",
@@ -3349,13 +3510,14 @@
 		"prefix": "hook_ckeditor_plugin_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_ckeditor_plugin_info_alter.",
+			" * Implements hook_ckeditor_plugin_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_ckeditor_plugin_info_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ckeditor_plugin_info_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available CKEditor plugins.",
@@ -3368,13 +3530,14 @@
 		"prefix": "hook_ckeditor_css_alter",
 		"body": [
 			"/**",
-			" * Implements hook_ckeditor_css_alter.",
+			" * Implements hook_ckeditor_css_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_ckeditor_css_alter(array &\\$css, Editor \\$editor) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ckeditor_css_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of CSS files that will be added to a CKEditor instance.",
@@ -3390,13 +3553,14 @@
 		"prefix": "hook_comment_links_alter",
 		"body": [
 			"/**",
-			" * Implements hook_comment_links_alter.",
+			" * Implements hook_comment_links_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_comment_links_alter(array &\\$links, CommentInterface \\$entity, array &\\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_comment_links_alter",
 			"Drupal 8+",
 			"",
 			"Alter the links of a comment."
@@ -3407,13 +3571,14 @@
 		"prefix": "hook_config_translation_info",
 		"body": [
 			"/**",
-			" * Implements hook_config_translation_info.",
+			" * Implements hook_config_translation_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_config_translation_info(&\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_config_translation_info",
 			"Drupal 8+",
 			"",
 			"Introduce dynamic translation tabs for translation of configuration.",
@@ -3430,13 +3595,14 @@
 		"prefix": "hook_config_translation_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_config_translation_info_alter.",
+			" * Implements hook_config_translation_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_config_translation_info_alter(&\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_config_translation_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter existing translation tabs for translation of configuration.",
@@ -3451,13 +3617,14 @@
 		"prefix": "hook_contextual_links_view_alter",
 		"body": [
 			"/**",
-			" * Implements hook_contextual_links_view_alter.",
+			" * Implements hook_contextual_links_view_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_contextual_links_view_alter(&\\$element, \\$items) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_contextual_links_view_alter",
 			"Drupal 8+",
 			"",
 			"Alter a contextual links element before it is rendered.",
@@ -3472,13 +3639,14 @@
 		"prefix": "hook_editor_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_editor_info_alter.",
+			" * Implements hook_editor_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_editor_info_alter(array &\\$editors) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_editor_info_alter",
 			"Drupal 8+",
 			"",
 			"Performs alterations on text editor definitions."
@@ -3489,13 +3657,14 @@
 		"prefix": "hook_editor_js_settings_alter",
 		"body": [
 			"/**",
-			" * Implements hook_editor_js_settings_alter.",
+			" * Implements hook_editor_js_settings_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_editor_js_settings_alter(array &\\$settings) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_editor_js_settings_alter",
 			"Drupal 8+",
 			"",
 			"Modifies JavaScript settings that are added for text editors."
@@ -3506,13 +3675,14 @@
 		"prefix": "hook_editor_xss_filter_alter",
 		"body": [
 			"/**",
-			" * Implements hook_editor_xss_filter_alter.",
+			" * Implements hook_editor_xss_filter_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_editor_xss_filter_alter(&\\$editor_xss_filter_class, FilterFormatInterface \\$format, FilterFormatInterface \\$original_format = NULL) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_editor_xss_filter_alter",
 			"Drupal 8+",
 			"",
 			"Modifies the text editor XSS filter that will used for the given text format.",
@@ -3525,13 +3695,14 @@
 		"prefix": "hook_field_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_info_alter.",
+			" * Implements hook_field_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_info_alter(&\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on Field API field types."
@@ -3542,13 +3713,14 @@
 		"prefix": "hook_field_ui_preconfigured_options_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_ui_preconfigured_options_alter.",
+			" * Implements hook_field_ui_preconfigured_options_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_ui_preconfigured_options_alter(array &\\$options, \\$field_type) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_ui_preconfigured_options_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on preconfigured field options."
@@ -3559,13 +3731,14 @@
 		"prefix": "hook_field_storage_config_update_forbid",
 		"body": [
 			"/**",
-			" * Implements hook_field_storage_config_update_forbid.",
+			" * Implements hook_field_storage_config_update_forbid().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_storage_config_update_forbid(\\Drupal\\field\\FieldStorageConfigInterface \\$field_storage, \\Drupal\\field\\FieldStorageConfigInterface \\$prior_field_storage) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_storage_config_update_forbid",
 			"Drupal 8+",
 			"",
 			"Forbid a field storage update from occurring.",
@@ -3584,13 +3757,14 @@
 		"prefix": "hook_field_widget_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_widget_info_alter.",
+			" * Implements hook_field_widget_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_widget_info_alter(array &\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_widget_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on Field API widget types."
@@ -3601,13 +3775,14 @@
 		"prefix": "hook_field_widget_form_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_widget_form_alter.",
+			" * Implements hook_field_widget_form_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_widget_form_alter(&\\$element, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state, \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_widget_form_alter",
 			"Drupal 8+",
 			"",
 			"Alter forms for field widgets provided by other modules.",
@@ -3622,13 +3797,14 @@
 		"prefix": "hook_field_widget_WIDGET_TYPE_form_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_widget_WIDGET_TYPE_form_alter.",
+			" * Implements hook_field_widget_WIDGET_TYPE_form_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_widget_${2:WIDGET_TYPE}_form_alter(&\\$element, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state, \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_widget_WIDGET_TYPE_form_alter",
 			"Drupal 8+",
 			"",
 			"Alter widget forms for a specific widget provided by another module.",
@@ -3646,13 +3822,14 @@
 		"prefix": "hook_field_widget_multivalue_form_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_widget_multivalue_form_alter.",
+			" * Implements hook_field_widget_multivalue_form_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_widget_multivalue_form_alter(array &\\$elements, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_widget_multivalue_form_alter",
 			"Drupal 8+",
 			"",
 			"Alter forms for multi-value field widgets provided by other modules.",
@@ -3665,13 +3842,14 @@
 		"prefix": "hook_field_widget_multivalue_WIDGET_TYPE_form_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_widget_multivalue_WIDGET_TYPE_form_alter.",
+			" * Implements hook_field_widget_multivalue_WIDGET_TYPE_form_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_widget_multivalue_${2:WIDGET_TYPE}_form_alter(array &\\$elements, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_widget_multivalue_WIDGET_TYPE_form_alter",
 			"Drupal 8+",
 			"",
 			"Alter multi-value widget forms for a widget provided by another module.",
@@ -3687,13 +3865,14 @@
 		"prefix": "hook_field_formatter_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_formatter_info_alter.",
+			" * Implements hook_field_formatter_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_formatter_info_alter(array &\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_formatter_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on Field API formatter types."
@@ -3704,13 +3883,14 @@
 		"prefix": "hook_field_info_max_weight",
 		"body": [
 			"/**",
-			" * Implements hook_field_info_max_weight.",
+			" * Implements hook_field_info_max_weight().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_info_max_weight(\\$entity_type, \\$bundle, \\$context, \\$context_mode) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_info_max_weight",
 			"Drupal 8+",
 			"",
 			"Returns the maximum weight for the entity components handled by the module.",
@@ -3723,13 +3903,14 @@
 		"prefix": "hook_field_purge_field_storage",
 		"body": [
 			"/**",
-			" * Implements hook_field_purge_field_storage.",
+			" * Implements hook_field_purge_field_storage().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_purge_field_storage(\\Drupal\\field\\Entity\\FieldStorageConfig \\$field_storage) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_purge_field_storage",
 			"Drupal 8+",
 			"",
 			"Acts when a field storage definition is being purged.",
@@ -3744,13 +3925,14 @@
 		"prefix": "hook_field_purge_field",
 		"body": [
 			"/**",
-			" * Implements hook_field_purge_field.",
+			" * Implements hook_field_purge_field().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_purge_field(\\Drupal\\field\\Entity\\FieldConfig \\$field) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_purge_field",
 			"Drupal 8+",
 			"",
 			"Acts when a field is being purged.",
@@ -3765,13 +3947,14 @@
 		"prefix": "hook_field_formatter_third_party_settings_form",
 		"body": [
 			"/**",
-			" * Implements hook_field_formatter_third_party_settings_form.",
+			" * Implements hook_field_formatter_third_party_settings_form().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_formatter_third_party_settings_form(\\Drupal\\Core\\Field\\FormatterInterface \\$plugin, \\Drupal\\Core\\Field\\FieldDefinitionInterface \\$field_definition, \\$view_mode, array \\$form, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_formatter_third_party_settings_form",
 			"Drupal 8+",
 			"",
 			"Allow modules to add settings to field formatters provided by other modules."
@@ -3782,13 +3965,14 @@
 		"prefix": "hook_field_widget_third_party_settings_form",
 		"body": [
 			"/**",
-			" * Implements hook_field_widget_third_party_settings_form.",
+			" * Implements hook_field_widget_third_party_settings_form().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_widget_third_party_settings_form(\\Drupal\\Core\\Field\\WidgetInterface \\$plugin, \\Drupal\\Core\\Field\\FieldDefinitionInterface \\$field_definition, \\$form_mode, array \\$form, \\Drupal\\Core\\Form\\FormStateInterface \\$form_state) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_widget_third_party_settings_form",
 			"Drupal 8+",
 			"",
 			"Allow modules to add settings to field widgets provided by other modules."
@@ -3799,13 +3983,14 @@
 		"prefix": "hook_field_formatter_settings_summary_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_formatter_settings_summary_alter.",
+			" * Implements hook_field_formatter_settings_summary_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_formatter_settings_summary_alter(array &\\$summary, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_formatter_settings_summary_alter",
 			"Drupal 8+",
 			"",
 			"Alters the field formatter settings summary."
@@ -3816,13 +4001,14 @@
 		"prefix": "hook_field_widget_settings_summary_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_widget_settings_summary_alter.",
+			" * Implements hook_field_widget_settings_summary_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_widget_settings_summary_alter(array &\\$summary, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_widget_settings_summary_alter",
 			"Drupal 8+",
 			"",
 			"Alters the field widget settings summary."
@@ -3833,13 +4019,14 @@
 		"prefix": "hook_file_validate",
 		"body": [
 			"/**",
-			" * Implements hook_file_validate.",
+			" * Implements hook_file_validate().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_file_validate(Drupal\\file\\FileInterface \\$file) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_file_validate",
 			"Drupal 8+",
 			"",
 			"Check that files meet a given criteria.",
@@ -3852,13 +4039,14 @@
 		"prefix": "hook_file_copy",
 		"body": [
 			"/**",
-			" * Implements hook_file_copy.",
+			" * Implements hook_file_copy().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_file_copy(Drupal\\file\\FileInterface \\$file, Drupal\\file\\FileInterface \\$source) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_file_copy",
 			"Drupal 8+",
 			"",
 			"Respond to a file that has been copied."
@@ -3869,13 +4057,14 @@
 		"prefix": "hook_file_move",
 		"body": [
 			"/**",
-			" * Implements hook_file_move.",
+			" * Implements hook_file_move().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_file_move(Drupal\\file\\FileInterface \\$file, Drupal\\file\\FileInterface \\$source) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_file_move",
 			"Drupal 8+",
 			"",
 			"Respond to a file that has been moved."
@@ -3886,13 +4075,14 @@
 		"prefix": "hook_filter_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_filter_info_alter.",
+			" * Implements hook_filter_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_filter_info_alter(&\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_filter_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on filter definitions."
@@ -3903,13 +4093,14 @@
 		"prefix": "hook_filter_secure_image_alter",
 		"body": [
 			"/**",
-			" * Implements hook_filter_secure_image_alter.",
+			" * Implements hook_filter_secure_image_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_filter_secure_image_alter(&\\$image) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_filter_secure_image_alter",
 			"Drupal 8+",
 			"",
 			"Alters images with an invalid source.",
@@ -3923,13 +4114,14 @@
 		"prefix": "hook_filter_format_disable",
 		"body": [
 			"/**",
-			" * Implements hook_filter_format_disable.",
+			" * Implements hook_filter_format_disable().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_filter_format_disable(\\$format) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_filter_format_disable",
 			"Drupal 8+",
 			"",
 			"Perform actions when a text format has been disabled."
@@ -3940,13 +4132,14 @@
 		"prefix": "hook_hal_type_uri_alter",
 		"body": [
 			"/**",
-			" * Implements hook_hal_type_uri_alter.",
+			" * Implements hook_hal_type_uri_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_hal_type_uri_alter(&\\$uri, \\$context = []) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_hal_type_uri_alter",
 			"Drupal 8+",
 			"",
 			"Alter the HAL type URI.",
@@ -3959,13 +4152,14 @@
 		"prefix": "hook_hal_relation_uri_alter",
 		"body": [
 			"/**",
-			" * Implements hook_hal_relation_uri_alter.",
+			" * Implements hook_hal_relation_uri_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_hal_relation_uri_alter(&\\$uri, \\$context = []) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_hal_relation_uri_alter",
 			"Drupal 8+",
 			"",
 			"Alter the HAL relation URI.",
@@ -3978,13 +4172,14 @@
 		"prefix": "hook_help",
 		"body": [
 			"/**",
-			" * Implements hook_help.",
+			" * Implements hook_help().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_help(\\$route_name, \\Drupal\\Core\\Routing\\RouteMatchInterface \\$route_match) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_help",
 			"Drupal 8+",
 			"",
 			"Provide online user help.",
@@ -4008,13 +4203,14 @@
 		"prefix": "hook_help_section_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_help_section_info_alter.",
+			" * Implements hook_help_section_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_help_section_info_alter(array &\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_help_section_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on help page section plugin definitions.",
@@ -4027,13 +4223,14 @@
 		"prefix": "hook_help_topics_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_help_topics_info_alter.",
+			" * Implements hook_help_topics_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_help_topics_info_alter(array &\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_help_topics_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on help topic definitions."
@@ -4044,13 +4241,14 @@
 		"prefix": "hook_image_effect_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_image_effect_info_alter.",
+			" * Implements hook_image_effect_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_image_effect_info_alter(&\\$effects) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_image_effect_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the information provided in \\Drupal\\image\\Annotation\\ImageEffect."
@@ -4061,13 +4259,14 @@
 		"prefix": "hook_image_style_flush",
 		"body": [
 			"/**",
-			" * Implements hook_image_style_flush.",
+			" * Implements hook_image_style_flush().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_image_style_flush(\\$style) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_image_style_flush",
 			"Drupal 8+",
 			"",
 			"Respond to image style flushing.",
@@ -4083,13 +4282,14 @@
 		"prefix": "hook_jsonapi_entity_filter_access",
 		"body": [
 			"/**",
-			" * Implements hook_jsonapi_entity_filter_access.",
+			" * Implements hook_jsonapi_entity_filter_access().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_jsonapi_entity_filter_access(\\Drupal\\Core\\Entity\\EntityTypeInterface \\$entity_type, \\Drupal\\Core\\Session\\AccountInterface \\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_jsonapi_entity_filter_access",
 			"Drupal 8+",
 			"",
 			"Controls access when filtering by entity data via JSON:API.",
@@ -4103,13 +4303,14 @@
 		"prefix": "hook_jsonapi_ENTITY_TYPE_filter_access",
 		"body": [
 			"/**",
-			" * Implements hook_jsonapi_ENTITY_TYPE_filter_access.",
+			" * Implements hook_jsonapi_ENTITY_TYPE_filter_access().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_jsonapi_${2:ENTITY_TYPE}_filter_access(\\Drupal\\Core\\Entity\\EntityTypeInterface \\$entity_type, \\Drupal\\Core\\Session\\AccountInterface \\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_jsonapi_ENTITY_TYPE_filter_access",
 			"Drupal 8+",
 			"",
 			"Controls access to filtering by entity data via JSON:API.",
@@ -4125,13 +4326,14 @@
 		"prefix": "hook_jsonapi_entity_field_filter_access",
 		"body": [
 			"/**",
-			" * Implements hook_jsonapi_entity_field_filter_access.",
+			" * Implements hook_jsonapi_entity_field_filter_access().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_jsonapi_entity_field_filter_access(\\Drupal\\Core\\Field\\FieldDefinitionInterface \\$field_definition, \\Drupal\\Core\\Session\\AccountInterface \\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_jsonapi_entity_field_filter_access",
 			"Drupal 8+",
 			"",
 			"Restricts filtering access to the given field.",
@@ -4157,13 +4359,14 @@
 		"prefix": "hook_language_types_info",
 		"body": [
 			"/**",
-			" * Implements hook_language_types_info.",
+			" * Implements hook_language_types_info().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_language_types_info() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_language_types_info",
 			"Drupal 8+",
 			"",
 			"Define language types."
@@ -4174,13 +4377,14 @@
 		"prefix": "hook_language_types_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_language_types_info_alter.",
+			" * Implements hook_language_types_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_language_types_info_alter(array &\\$language_types) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_language_types_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on language types."
@@ -4191,13 +4395,14 @@
 		"prefix": "hook_language_negotiation_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_language_negotiation_info_alter.",
+			" * Implements hook_language_negotiation_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_language_negotiation_info_alter(array &\\$negotiation_info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_language_negotiation_info_alter",
 			"Drupal 8+",
 			"",
 			"Perform alterations on language negotiation methods."
@@ -4208,13 +4413,14 @@
 		"prefix": "hook_language_fallback_candidates_alter",
 		"body": [
 			"/**",
-			" * Implements hook_language_fallback_candidates_alter.",
+			" * Implements hook_language_fallback_candidates_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_language_fallback_candidates_alter(array &\\$candidates, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_language_fallback_candidates_alter",
 			"Drupal 8+",
 			"",
 			"Allow modules to alter the language fallback candidates."
@@ -4225,13 +4431,14 @@
 		"prefix": "hook_language_fallback_candidates_OPERATION_alter",
 		"body": [
 			"/**",
-			" * Implements hook_language_fallback_candidates_OPERATION_alter.",
+			" * Implements hook_language_fallback_candidates_OPERATION_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_language_fallback_candidates_${2:OPERATION}_alter(array &\\$candidates, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_language_fallback_candidates_OPERATION_alter",
 			"Drupal 8+",
 			"",
 			"Allow modules to alter the fallback candidates for specific operations."
@@ -4242,13 +4449,14 @@
 		"prefix": "hook_locale_translation_projects_alter",
 		"body": [
 			"/**",
-			" * Implements hook_locale_translation_projects_alter.",
+			" * Implements hook_locale_translation_projects_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_locale_translation_projects_alter(&\\$projects) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_locale_translation_projects_alter",
 			"Drupal 8+",
 			"",
 			"Alter the list of projects to be updated by locale's interface translation.",
@@ -4275,13 +4483,14 @@
 		"prefix": "hook_media_source_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_media_source_info_alter.",
+			" * Implements hook_media_source_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_media_source_info_alter(array &\\$sources) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_media_source_info_alter",
 			"Drupal 8+",
 			"",
 			"Alters the information provided in \\Drupal\\media\\Annotation\\MediaSource."
@@ -4292,13 +4501,14 @@
 		"prefix": "hook_oembed_resource_url_alter",
 		"body": [
 			"/**",
-			" * Implements hook_oembed_resource_url_alter.",
+			" * Implements hook_oembed_resource_url_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_oembed_resource_url_alter(array &\\$parsed_url, \\Drupal\\media\\OEmbed\\Provider \\$provider) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_oembed_resource_url_alter",
 			"Drupal 8+",
 			"",
 			"Alters an oEmbed resource URL before it is fetched."
@@ -4309,13 +4519,14 @@
 		"prefix": "hook_migrate_prepare_row",
 		"body": [
 			"/**",
-			" * Implements hook_migrate_prepare_row.",
+			" * Implements hook_migrate_prepare_row().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_migrate_prepare_row(Row \\$row, MigrateSourceInterface \\$source, MigrationInterface \\$migration) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_migrate_prepare_row",
 			"Drupal 8+",
 			"",
 			"Allows adding data to a row before processing it.",
@@ -4330,13 +4541,14 @@
 		"prefix": "hook_migrate_MIGRATION_ID_prepare_row",
 		"body": [
 			"/**",
-			" * Implements hook_migrate_MIGRATION_ID_prepare_row.",
+			" * Implements hook_migrate_MIGRATION_ID_prepare_row().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_migrate_${2:MIGRATION_ID}_prepare_row(Row \\$row, MigrateSourceInterface \\$source, MigrationInterface \\$migration) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_migrate_MIGRATION_ID_prepare_row",
 			"Drupal 8+",
 			"",
 			"Allows adding data to a row for a migration with the specified ID.",
@@ -4349,13 +4561,14 @@
 		"prefix": "hook_migration_plugins_alter",
 		"body": [
 			"/**",
-			" * Implements hook_migration_plugins_alter.",
+			" * Implements hook_migration_plugins_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_migration_plugins_alter(array &\\$migrations) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_migration_plugins_alter",
 			"Drupal 8+",
 			"",
 			"Allows altering the list of discovered migration plugins.",
@@ -4370,13 +4583,14 @@
 		"prefix": "hook_node_grants",
 		"body": [
 			"/**",
-			" * Implements hook_node_grants.",
+			" * Implements hook_node_grants().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_node_grants(\\Drupal\\Core\\Session\\AccountInterface \\$account, \\$op) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_node_grants",
 			"Drupal 8+",
 			"",
 			"Inform the node access system what permissions the user has.",
@@ -4408,13 +4622,14 @@
 		"prefix": "hook_node_access_records",
 		"body": [
 			"/**",
-			" * Implements hook_node_access_records.",
+			" * Implements hook_node_access_records().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_node_access_records(\\Drupal\\node\\NodeInterface \\$node) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_node_access_records",
 			"Drupal 8+",
 			"",
 			"Set permissions for a node to be written to the database.",
@@ -4458,13 +4673,14 @@
 		"prefix": "hook_node_access_records_alter",
 		"body": [
 			"/**",
-			" * Implements hook_node_access_records_alter.",
+			" * Implements hook_node_access_records_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_node_access_records_alter(&\\$grants, Drupal\\node\\NodeInterface \\$node) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_node_access_records_alter",
 			"Drupal 8+",
 			"",
 			"Alter permissions for a node before it is written to the database.",
@@ -4489,13 +4705,14 @@
 		"prefix": "hook_node_grants_alter",
 		"body": [
 			"/**",
-			" * Implements hook_node_grants_alter.",
+			" * Implements hook_node_grants_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_node_grants_alter(&\\$grants, \\Drupal\\Core\\Session\\AccountInterface \\$account, \\$op) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_node_grants_alter",
 			"Drupal 8+",
 			"",
 			"Alter user access rules when trying to view, edit or delete a node.",
@@ -4519,13 +4736,14 @@
 		"prefix": "hook_node_search_result",
 		"body": [
 			"/**",
-			" * Implements hook_node_search_result.",
+			" * Implements hook_node_search_result().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_node_search_result(\\Drupal\\node\\NodeInterface \\$node) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_node_search_result",
 			"Drupal 8+",
 			"",
 			"Act on a node being displayed as a search result.",
@@ -4538,13 +4756,14 @@
 		"prefix": "hook_node_update_index",
 		"body": [
 			"/**",
-			" * Implements hook_node_update_index.",
+			" * Implements hook_node_update_index().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_node_update_index(\\Drupal\\node\\NodeInterface \\$node) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_node_update_index",
 			"Drupal 8+",
 			"",
 			"Act on a node being indexed for searching.",
@@ -4557,13 +4776,14 @@
 		"prefix": "hook_ranking",
 		"body": [
 			"/**",
-			" * Implements hook_ranking.",
+			" * Implements hook_ranking().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_ranking() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_ranking",
 			"Drupal 8+",
 			"",
 			"Provide additional methods of scoring for core search results for nodes.",
@@ -4589,13 +4809,14 @@
 		"prefix": "hook_node_links_alter",
 		"body": [
 			"/**",
-			" * Implements hook_node_links_alter.",
+			" * Implements hook_node_links_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_node_links_alter(array &\\$links, NodeInterface \\$entity, array &\\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_node_links_alter",
 			"Drupal 8+",
 			"",
 			"Alter the links of a node."
@@ -4606,13 +4827,14 @@
 		"prefix": "hook_options_list_alter",
 		"body": [
 			"/**",
-			" * Implements hook_options_list_alter.",
+			" * Implements hook_options_list_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_options_list_alter(array &\\$options, array \\$context) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_options_list_alter",
 			"Drupal 8+",
 			"",
 			"Alters the list of options to be displayed for a field.",
@@ -4624,13 +4846,14 @@
 		"prefix": "hook_quickedit_editor_alter",
 		"body": [
 			"/**",
-			" * Implements hook_quickedit_editor_alter.",
+			" * Implements hook_quickedit_editor_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_quickedit_editor_alter(&\\$editors) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_quickedit_editor_alter",
 			"Drupal 8+",
 			"",
 			"Allow modules to alter in-place editor plugin metadata.",
@@ -4643,13 +4866,14 @@
 		"prefix": "hook_quickedit_render_field",
 		"body": [
 			"/**",
-			" * Implements hook_quickedit_render_field.",
+			" * Implements hook_quickedit_render_field().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_quickedit_render_field(Drupal\\Core\\Entity\\EntityInterface \\$entity, \\$field_name, \\$view_mode_id, \\$langcode) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_quickedit_render_field",
 			"Drupal 8+",
 			"",
 			"Returns a renderable array for the value of a single field in an entity.",
@@ -4673,13 +4897,14 @@
 		"prefix": "hook_rdf_namespaces",
 		"body": [
 			"/**",
-			" * Implements hook_rdf_namespaces.",
+			" * Implements hook_rdf_namespaces().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_rdf_namespaces() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_rdf_namespaces",
 			"Drupal 8+",
 			"",
 			"Allow modules to define namespaces for RDF mappings.",
@@ -4694,13 +4919,14 @@
 		"prefix": "hook_rest_resource_alter",
 		"body": [
 			"/**",
-			" * Implements hook_rest_resource_alter.",
+			" * Implements hook_rest_resource_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_rest_resource_alter(&\\$definitions) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_rest_resource_alter",
 			"Drupal 8+",
 			"",
 			"Alter the resource plugin definitions."
@@ -4711,13 +4937,14 @@
 		"prefix": "hook_search_preprocess",
 		"body": [
 			"/**",
-			" * Implements hook_search_preprocess.",
+			" * Implements hook_search_preprocess().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_search_preprocess(\\$text, \\$langcode = NULL) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_search_preprocess",
 			"Drupal 8+",
 			"",
 			"Preprocess text for search.",
@@ -4736,13 +4963,14 @@
 		"prefix": "hook_search_plugin_alter",
 		"body": [
 			"/**",
-			" * Implements hook_search_plugin_alter.",
+			" * Implements hook_search_plugin_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_search_plugin_alter(array &\\$definitions) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_search_plugin_alter",
 			"Drupal 8+",
 			"",
 			"Alter search plugin definitions."
@@ -4753,13 +4981,14 @@
 		"prefix": "hook_shortcut_default_set",
 		"body": [
 			"/**",
-			" * Implements hook_shortcut_default_set.",
+			" * Implements hook_shortcut_default_set().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_shortcut_default_set(\\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_shortcut_default_set",
 			"Drupal 8+",
 			"",
 			"Return the name of a default shortcut set for the provided user account.",
@@ -4778,13 +5007,14 @@
 		"prefix": "hook_system_themes_page_alter",
 		"body": [
 			"/**",
-			" * Implements hook_system_themes_page_alter.",
+			" * Implements hook_system_themes_page_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_system_themes_page_alter(&\\$theme_groups) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_system_themes_page_alter",
 			"Drupal 8+",
 			"",
 			"Alters theme operation links."
@@ -4795,13 +5025,14 @@
 		"prefix": "hook_toolbar",
 		"body": [
 			"/**",
-			" * Implements hook_toolbar.",
+			" * Implements hook_toolbar().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_toolbar() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_toolbar",
 			"Drupal 8+",
 			"",
 			"Add items to the toolbar menu.",
@@ -4828,13 +5059,14 @@
 		"prefix": "hook_toolbar_alter",
 		"body": [
 			"/**",
-			" * Implements hook_toolbar_alter.",
+			" * Implements hook_toolbar_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_toolbar_alter(&\\$items) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_toolbar_alter",
 			"Drupal 8+",
 			"",
 			"Alter the toolbar menu after hook_toolbar() is invoked.",
@@ -4849,13 +5081,14 @@
 		"prefix": "hook_tour_tips_alter",
 		"body": [
 			"/**",
-			" * Implements hook_tour_tips_alter.",
+			" * Implements hook_tour_tips_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_tour_tips_alter(array &\\$tour_tips, Drupal\\Core\\Entity\\EntityInterface \\$entity) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_tour_tips_alter",
 			"Drupal 8+",
 			"",
 			"Allow modules to alter tour items before render."
@@ -4866,13 +5099,14 @@
 		"prefix": "hook_tour_tips_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_tour_tips_info_alter.",
+			" * Implements hook_tour_tips_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_tour_tips_info_alter(&\\$info) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_tour_tips_info_alter",
 			"Drupal 8+",
 			"",
 			"Allow modules to alter tip plugin definitions."
@@ -4883,13 +5117,14 @@
 		"prefix": "hook_update_projects_alter",
 		"body": [
 			"/**",
-			" * Implements hook_update_projects_alter.",
+			" * Implements hook_update_projects_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_update_projects_alter(&\\$projects) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_update_projects_alter",
 			"Drupal 8+",
 			"",
 			"Alter the list of projects before fetching data and comparing versions.",
@@ -4909,13 +5144,14 @@
 		"prefix": "hook_update_status_alter",
 		"body": [
 			"/**",
-			" * Implements hook_update_status_alter.",
+			" * Implements hook_update_status_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_update_status_alter(&\\$projects) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_update_status_alter",
 			"Drupal 8+",
 			"",
 			"Alter the information about available updates for projects."
@@ -4926,13 +5162,14 @@
 		"prefix": "hook_verify_update_archive",
 		"body": [
 			"/**",
-			" * Implements hook_verify_update_archive.",
+			" * Implements hook_verify_update_archive().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_verify_update_archive(\\$project, \\$archive_file, \\$directory) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_verify_update_archive",
 			"Drupal 8+",
 			"",
 			"Verify an archive after it has been downloaded and extracted."
@@ -4943,13 +5180,14 @@
 		"prefix": "hook_user_cancel",
 		"body": [
 			"/**",
-			" * Implements hook_user_cancel.",
+			" * Implements hook_user_cancel().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_user_cancel(\\$edit, UserInterface \\$account, \\$method) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_user_cancel",
 			"Drupal 8+",
 			"",
 			"Act on user account cancellations.",
@@ -4970,13 +5208,14 @@
 		"prefix": "hook_user_cancel_methods_alter",
 		"body": [
 			"/**",
-			" * Implements hook_user_cancel_methods_alter.",
+			" * Implements hook_user_cancel_methods_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_user_cancel_methods_alter(&\\$methods) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_user_cancel_methods_alter",
 			"Drupal 8+",
 			"",
 			"Modify account cancellation methods.",
@@ -4999,13 +5238,14 @@
 		"prefix": "hook_user_format_name_alter",
 		"body": [
 			"/**",
-			" * Implements hook_user_format_name_alter.",
+			" * Implements hook_user_format_name_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_user_format_name_alter(&\\$name, AccountInterface \\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_user_format_name_alter",
 			"Drupal 8+",
 			"",
 			"Alter the username that is displayed for a user.",
@@ -5020,13 +5260,14 @@
 		"prefix": "hook_user_login",
 		"body": [
 			"/**",
-			" * Implements hook_user_login.",
+			" * Implements hook_user_login().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_user_login(UserInterface \\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_user_login",
 			"Drupal 8+",
 			"",
 			"The user just logged in."
@@ -5037,13 +5278,14 @@
 		"prefix": "hook_user_logout",
 		"body": [
 			"/**",
-			" * Implements hook_user_logout.",
+			" * Implements hook_user_logout().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_user_logout(AccountInterface \\$account) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_user_logout",
 			"Drupal 8+",
 			"",
 			"The user just logged out."
@@ -5054,13 +5296,14 @@
 		"prefix": "hook_views_analyze",
 		"body": [
 			"/**",
-			" * Implements hook_views_analyze.",
+			" * Implements hook_views_analyze().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_analyze(Drupal\\views\\ViewExecutable \\$view) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_analyze",
 			"Drupal 8+",
 			"",
 			"Analyze a view to provide warnings about its configuration."
@@ -5071,13 +5314,14 @@
 		"prefix": "hook_views_data",
 		"body": [
 			"/**",
-			" * Implements hook_views_data.",
+			" * Implements hook_views_data().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_data() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_data",
 			"Drupal 8+",
 			"",
 			"Describe data tables and fields (or the equivalent) to Views.",
@@ -5090,13 +5334,14 @@
 		"prefix": "hook_views_data_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_data_alter.",
+			" * Implements hook_views_data_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_data_alter(array &\\$data) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_data_alter",
 			"Drupal 8+",
 			"",
 			"Alter the table and field information from hook_views_data()."
@@ -5107,13 +5352,14 @@
 		"prefix": "hook_field_views_data",
 		"body": [
 			"/**",
-			" * Implements hook_field_views_data.",
+			" * Implements hook_field_views_data().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_views_data(\\Drupal\\field\\FieldStorageConfigInterface \\$field_storage) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_views_data",
 			"Drupal 8+",
 			"",
 			"Override the default Views data for a Field API field.",
@@ -5129,13 +5375,14 @@
 		"prefix": "hook_field_views_data_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_views_data_alter.",
+			" * Implements hook_field_views_data_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_views_data_alter(array &\\$data, \\Drupal\\field\\FieldStorageConfigInterface \\$field_storage) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_views_data_alter",
 			"Drupal 8+",
 			"",
 			"Alter the Views data for a single Field API field.",
@@ -5150,13 +5397,14 @@
 		"prefix": "hook_field_views_data_views_data_alter",
 		"body": [
 			"/**",
-			" * Implements hook_field_views_data_views_data_alter.",
+			" * Implements hook_field_views_data_views_data_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_field_views_data_views_data_alter(array &\\$data, \\Drupal\\field\\FieldStorageConfigInterface \\$field) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_field_views_data_views_data_alter",
 			"Drupal 8+",
 			"",
 			"Alter the Views data on a per field basis.",
@@ -5178,13 +5426,14 @@
 		"prefix": "hook_views_query_substitutions",
 		"body": [
 			"/**",
-			" * Implements hook_views_query_substitutions.",
+			" * Implements hook_views_query_substitutions().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_query_substitutions(ViewExecutable \\$view) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_query_substitutions",
 			"Drupal 8+",
 			"",
 			"Replace special strings in the query before it is executed.",
@@ -5198,13 +5447,14 @@
 		"prefix": "hook_views_form_substitutions",
 		"body": [
 			"/**",
-			" * Implements hook_views_form_substitutions.",
+			" * Implements hook_views_form_substitutions().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_form_substitutions() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_form_substitutions",
 			"Drupal 8+",
 			"",
 			"Replace special strings when processing a view with form elements."
@@ -5215,13 +5465,14 @@
 		"prefix": "hook_views_pre_view",
 		"body": [
 			"/**",
-			" * Implements hook_views_pre_view.",
+			" * Implements hook_views_pre_view().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_pre_view(ViewExecutable \\$view, \\$display_id, array &\\$args) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_pre_view",
 			"Drupal 8+",
 			"",
 			"Alter a view at the very beginning of Views processing.",
@@ -5234,13 +5485,14 @@
 		"prefix": "hook_views_pre_build",
 		"body": [
 			"/**",
-			" * Implements hook_views_pre_build.",
+			" * Implements hook_views_pre_build().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_pre_build(ViewExecutable \\$view) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_pre_build",
 			"Drupal 8+",
 			"",
 			"Act on the view before the query is built, but after displays are attached.",
@@ -5253,13 +5505,14 @@
 		"prefix": "hook_views_post_build",
 		"body": [
 			"/**",
-			" * Implements hook_views_post_build.",
+			" * Implements hook_views_post_build().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_post_build(ViewExecutable \\$view) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_post_build",
 			"Drupal 8+",
 			"",
 			"Act on the view immediately after the query is built.",
@@ -5272,13 +5525,14 @@
 		"prefix": "hook_views_pre_execute",
 		"body": [
 			"/**",
-			" * Implements hook_views_pre_execute.",
+			" * Implements hook_views_pre_execute().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_pre_execute(ViewExecutable \\$view) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_pre_execute",
 			"Drupal 8+",
 			"",
 			"Act on the view after the query is built and just before it is executed.",
@@ -5291,13 +5545,14 @@
 		"prefix": "hook_views_post_execute",
 		"body": [
 			"/**",
-			" * Implements hook_views_post_execute.",
+			" * Implements hook_views_post_execute().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_post_execute(ViewExecutable \\$view) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_post_execute",
 			"Drupal 8+",
 			"",
 			"Act on the view immediately after the query has been executed.",
@@ -5312,13 +5567,14 @@
 		"prefix": "hook_views_pre_render",
 		"body": [
 			"/**",
-			" * Implements hook_views_pre_render.",
+			" * Implements hook_views_pre_render().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_pre_render(ViewExecutable \\$view) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_pre_render",
 			"Drupal 8+",
 			"",
 			"Act on the view immediately before rendering it.",
@@ -5334,13 +5590,14 @@
 		"prefix": "hook_views_post_render",
 		"body": [
 			"/**",
-			" * Implements hook_views_post_render.",
+			" * Implements hook_views_post_render().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_post_render(ViewExecutable \\$view, &\\$output, CachePluginBase \\$cache) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_post_render",
 			"Drupal 8+",
 			"",
 			"Post-process any rendered data.",
@@ -5357,13 +5614,14 @@
 		"prefix": "hook_views_query_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_query_alter.",
+			" * Implements hook_views_query_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_query_alter(ViewExecutable \\$view, QueryPluginBase \\$query) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_query_alter",
 			"Drupal 8+",
 			"",
 			"Alter the query before it is executed."
@@ -5374,13 +5632,14 @@
 		"prefix": "hook_views_preview_info_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_preview_info_alter.",
+			" * Implements hook_views_preview_info_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_preview_info_alter(array &\\$rows, ViewExecutable \\$view) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_preview_info_alter",
 			"Drupal 8+",
 			"",
 			"Alter the view preview information.",
@@ -5394,13 +5653,14 @@
 		"prefix": "hook_views_invalidate_cache",
 		"body": [
 			"/**",
-			" * Implements hook_views_invalidate_cache.",
+			" * Implements hook_views_invalidate_cache().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_invalidate_cache() {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_invalidate_cache",
 			"Drupal 8+",
 			"",
 			"Allow modules to respond to the invalidation of the Views cache.",
@@ -5413,13 +5673,14 @@
 		"prefix": "hook_views_plugins_access_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_access_alter.",
+			" * Implements hook_views_plugins_access_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_access_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_access_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views access plugins.",
@@ -5432,13 +5693,14 @@
 		"prefix": "hook_views_plugins_argument_default_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_argument_default_alter.",
+			" * Implements hook_views_plugins_argument_default_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_argument_default_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_argument_default_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views default argument plugins.",
@@ -5451,13 +5713,14 @@
 		"prefix": "hook_views_plugins_argument_validator_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_argument_validator_alter.",
+			" * Implements hook_views_plugins_argument_validator_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_argument_validator_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_argument_validator_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views argument validation plugins.",
@@ -5470,13 +5733,14 @@
 		"prefix": "hook_views_plugins_cache_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_cache_alter.",
+			" * Implements hook_views_plugins_cache_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_cache_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_cache_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views cache plugins.",
@@ -5489,13 +5753,14 @@
 		"prefix": "hook_views_plugins_display_extenders_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_display_extenders_alter.",
+			" * Implements hook_views_plugins_display_extenders_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_display_extenders_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_display_extenders_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views display extender plugins.",
@@ -5508,13 +5773,14 @@
 		"prefix": "hook_views_plugins_display_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_display_alter.",
+			" * Implements hook_views_plugins_display_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_display_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_display_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views display plugins.",
@@ -5527,13 +5793,14 @@
 		"prefix": "hook_views_plugins_exposed_form_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_exposed_form_alter.",
+			" * Implements hook_views_plugins_exposed_form_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_exposed_form_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_exposed_form_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views exposed form plugins.",
@@ -5546,13 +5813,14 @@
 		"prefix": "hook_views_plugins_join_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_join_alter.",
+			" * Implements hook_views_plugins_join_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_join_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_join_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views join plugins.",
@@ -5565,13 +5833,14 @@
 		"prefix": "hook_views_plugins_pager_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_pager_alter.",
+			" * Implements hook_views_plugins_pager_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_pager_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_pager_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views pager plugins.",
@@ -5584,13 +5853,14 @@
 		"prefix": "hook_views_plugins_query_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_query_alter.",
+			" * Implements hook_views_plugins_query_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_query_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_query_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views query plugins.",
@@ -5603,13 +5873,14 @@
 		"prefix": "hook_views_plugins_row_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_row_alter.",
+			" * Implements hook_views_plugins_row_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_row_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_row_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views row plugins.",
@@ -5622,13 +5893,14 @@
 		"prefix": "hook_views_plugins_style_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_style_alter.",
+			" * Implements hook_views_plugins_style_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_style_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_style_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views style plugins.",
@@ -5641,13 +5913,14 @@
 		"prefix": "hook_views_plugins_wizard_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_wizard_alter.",
+			" * Implements hook_views_plugins_wizard_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_wizard_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_wizard_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views wizard plugins.",
@@ -5660,13 +5933,14 @@
 		"prefix": "hook_views_plugins_area_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_area_alter.",
+			" * Implements hook_views_plugins_area_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_area_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_area_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views area handler plugins.",
@@ -5679,13 +5953,14 @@
 		"prefix": "hook_views_plugins_argument_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_argument_alter.",
+			" * Implements hook_views_plugins_argument_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_argument_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_argument_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views argument handler plugins.",
@@ -5698,13 +5973,14 @@
 		"prefix": "hook_views_plugins_field_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_field_alter.",
+			" * Implements hook_views_plugins_field_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_field_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_field_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views field handler plugins.",
@@ -5717,13 +5993,14 @@
 		"prefix": "hook_views_plugins_filter_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_filter_alter.",
+			" * Implements hook_views_plugins_filter_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_filter_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_filter_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views filter handler plugins.",
@@ -5736,13 +6013,14 @@
 		"prefix": "hook_views_plugins_relationship_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_relationship_alter.",
+			" * Implements hook_views_plugins_relationship_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_relationship_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_relationship_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views relationship handler plugins.",
@@ -5755,13 +6033,14 @@
 		"prefix": "hook_views_plugins_sort_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_plugins_sort_alter.",
+			" * Implements hook_views_plugins_sort_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_plugins_sort_alter(array &\\$plugins) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_plugins_sort_alter",
 			"Drupal 8+",
 			"",
 			"Modify the list of available views sort handler plugins.",
@@ -5774,13 +6053,14 @@
 		"prefix": "hook_views_ui_display_top_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_ui_display_top_alter.",
+			" * Implements hook_views_ui_display_top_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_ui_display_top_alter(&\\$build, \\Drupal\\views_ui\\ViewUI \\$view, \\$display_id) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_ui_display_top_alter",
 			"Drupal 8+",
 			"",
 			"Alter the top of the display for the Views UI.",
@@ -5792,13 +6072,14 @@
 		"prefix": "hook_views_ui_display_tab_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_ui_display_tab_alter.",
+			" * Implements hook_views_ui_display_tab_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_ui_display_tab_alter(&\\$build, \\Drupal\\views_ui\\ViewUI \\$view, \\$display_id) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_ui_display_tab_alter",
 			"Drupal 8+",
 			"",
 			"Alter the renderable array representing the edit page for one display.",
@@ -5810,13 +6091,14 @@
 		"prefix": "hook_views_ui_display_top_links_alter",
 		"body": [
 			"/**",
-			" * Implements hook_views_ui_display_top_links_alter.",
+			" * Implements hook_views_ui_display_top_links_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_views_ui_display_top_links_alter(array &\\$links, ViewExecutable \\$view, \\$display_id) {",
 			"  $0",
 			"}"
 		],
 		"description": [
+			"hook_views_ui_display_top_links_alter",
 			"Drupal 8+",
 			"",
 			"Alter the links displayed at the top of the view edit form."
@@ -5827,7 +6109,7 @@
 		"prefix": "hook_path_insert",
 		"body": [
 			"/**",
-			" * Implements hook_path_insert.",
+			" * Implements hook_path_insert().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_path_insert(\\$path) {",
 			"  $0",
@@ -5835,6 +6117,7 @@
 			"//deprecated"
 		],
 		"description": [
+			"hook_path_insert (Deprecated)",
 			"Drupal 8+",
 			"",
 			"Respond to a path being inserted.",
@@ -5848,7 +6131,7 @@
 		"prefix": "hook_path_update",
 		"body": [
 			"/**",
-			" * Implements hook_path_update.",
+			" * Implements hook_path_update().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_path_update(\\$path) {",
 			"  $0",
@@ -5856,6 +6139,7 @@
 			"//deprecated"
 		],
 		"description": [
+			"hook_path_update (Deprecated)",
 			"Drupal 8+",
 			"",
 			"Respond to a path being updated.",
@@ -5869,7 +6153,7 @@
 		"prefix": "hook_path_delete",
 		"body": [
 			"/**",
-			" * Implements hook_path_delete.",
+			" * Implements hook_path_delete().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_path_delete(\\$path) {",
 			"  $0",
@@ -5877,6 +6161,7 @@
 			"//deprecated"
 		],
 		"description": [
+			"hook_path_delete (Deprecated)",
 			"Drupal 8+",
 			"",
 			"Respond to a path being deleted.",
@@ -5890,7 +6175,7 @@
 		"prefix": "hook_rest_type_uri_alter",
 		"body": [
 			"/**",
-			" * Implements hook_rest_type_uri_alter.",
+			" * Implements hook_rest_type_uri_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_rest_type_uri_alter(&\\$uri, \\$context = []) {",
 			"  $0",
@@ -5898,6 +6183,7 @@
 			"//deprecated"
 		],
 		"description": [
+			"hook_rest_type_uri_alter (Deprecated)",
 			"Drupal 8+",
 			"",
 			"Alter the REST type URI.",
@@ -5911,7 +6197,7 @@
 		"prefix": "hook_rest_relation_uri_alter",
 		"body": [
 			"/**",
-			" * Implements hook_rest_relation_uri_alter.",
+			" * Implements hook_rest_relation_uri_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_rest_relation_uri_alter(&\\$uri, \\$context = []) {",
 			"  $0",
@@ -5919,6 +6205,7 @@
 			"//deprecated"
 		],
 		"description": [
+			"hook_rest_relation_uri_alter (Deprecated)",
 			"Drupal 8+",
 			"",
 			"Alter the REST relation URI.",
@@ -5932,7 +6219,7 @@
 		"prefix": "hook_simpletest_alter",
 		"body": [
 			"/**",
-			" * Implements hook_simpletest_alter.",
+			" * Implements hook_simpletest_alter().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_simpletest_alter(&\\$groups) {",
 			"  $0",
@@ -5940,6 +6227,7 @@
 			"//deprecated"
 		],
 		"description": [
+			"hook_simpletest_alter (Deprecated)",
 			"Drupal 8+",
 			"",
 			"Alter the list of tests.",
@@ -5954,7 +6242,7 @@
 		"prefix": "hook_test_group_started",
 		"body": [
 			"/**",
-			" * Implements hook_test_group_started.",
+			" * Implements hook_test_group_started().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_test_group_started() {",
 			"  $0",
@@ -5962,6 +6250,7 @@
 			"//deprecated"
 		],
 		"description": [
+			"hook_test_group_started (Deprecated)",
 			"Drupal 8+",
 			"",
 			"A test group has started.",
@@ -5978,7 +6267,7 @@
 		"prefix": "hook_test_group_finished",
 		"body": [
 			"/**",
-			" * Implements hook_test_group_finished.",
+			" * Implements hook_test_group_finished().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_test_group_finished() {",
 			"  $0",
@@ -5986,6 +6275,7 @@
 			"//deprecated"
 		],
 		"description": [
+			"hook_test_group_finished (Deprecated)",
 			"Drupal 8+",
 			"",
 			"A test group has finished.",
@@ -6002,7 +6292,7 @@
 		"prefix": "hook_test_finished",
 		"body": [
 			"/**",
-			" * Implements hook_test_finished.",
+			" * Implements hook_test_finished().",
 			" */",
 			"function ${1:${TM_FILENAME_BASE:hook}}_test_finished(\\$results) {",
 			"  $0",
@@ -6010,6 +6300,7 @@
 			"//deprecated"
 		],
 		"description": [
+			"hook_test_finished (Deprecated)",
 			"Drupal 8+",
 			"",
 			"An individual test has finished.",


### PR DESCRIPTION
- Add ‘()’ to end of hook docblock per coding standards
- Add hookname and deprecation warning to top of description blocks